### PR TITLE
Revive project for 2025-26 NBA season

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.mcp.json

--- a/actions/games.ts
+++ b/actions/games.ts
@@ -179,6 +179,13 @@ export const refreshGamesWithinOneMonth = async () => {
     );
 
     for (const game of allGames.data as (NBAGame & { datetime: string })[]) {
+      const isFinished = game.status === "Final";
+      const winnerTeam = isFinished
+        ? game.home_team_score > game.visitor_team_score
+          ? game.home_team.name
+          : game.visitor_team.name
+        : undefined;
+
       await prisma.game.upsert({
         where: {
           apiGameId: game.id,
@@ -188,6 +195,10 @@ export const refreshGamesWithinOneMonth = async () => {
           awayTeam: game.visitor_team.name,
           startTime: new Date(game.datetime),
           isPlayoff: game.postseason,
+          homeTeamScore: game.home_team_score ?? null,
+          awayTeamScore: game.visitor_team_score ?? null,
+          status: isNaN(new Date(game.status).getTime()) ? game.status : "Scheduled",
+          ...(winnerTeam ? { winnerTeam } : {}),
         },
         create: {
           apiGameId: game.id,
@@ -195,6 +206,10 @@ export const refreshGamesWithinOneMonth = async () => {
           awayTeam: game.visitor_team.name,
           startTime: new Date(game.datetime),
           isPlayoff: game.postseason,
+          homeTeamScore: game.home_team_score ?? null,
+          awayTeamScore: game.visitor_team_score ?? null,
+          status: isNaN(new Date(game.status).getTime()) ? game.status : "Scheduled",
+          ...(winnerTeam ? { winnerTeam } : {}),
         },
       });
     }
@@ -202,6 +217,34 @@ export const refreshGamesWithinOneMonth = async () => {
     console.error("Failed to refresh games from API (rate limited?):", e);
   }
 }
+
+export const fetchTodaysGamesFromDb = async (todayStr: string) => {
+  const startOfDay = new Date(`${todayStr}T00:00:00.000Z`);
+  const endOfDay = new Date(`${todayStr}T23:59:59.999Z`);
+
+  return await prisma.game.findMany({
+    where: {
+      startTime: {
+        gte: startOfDay,
+        lte: endOfDay,
+      },
+    },
+    include: { round: true },
+    orderBy: { startTime: "asc" },
+  });
+};
+
+export const fetchUpcomingGamesFromDb = async () => {
+  return await prisma.game.findMany({
+    where: {
+      startTime: {
+        gt: new Date(),
+      },
+    },
+    include: { round: true },
+    orderBy: { startTime: "asc" },
+  });
+};
 
 export const refreshGameRounds = async () => {
   const sortedPlayoffGamesByStartTime = await fetchAllSortedPlayoffGamesFromDb();

--- a/actions/games.ts
+++ b/actions/games.ts
@@ -166,36 +166,40 @@ export const fetchFinishedGamesSince = async (date: Date) => {
 };
 
 export const refreshGamesWithinOneMonth = async () => {
-  const today = format(new Date(), "yyyy-MM-dd");
-  const oneMonthFromToday = format(
-    new Date(new Date().setMonth(new Date().getMonth() + 1)),
-    "yyyy-MM-dd",
-  );
+  try {
+    const today = format(new Date(), "yyyy-MM-dd");
+    const oneMonthFromToday = format(
+      new Date(new Date().setMonth(new Date().getMonth() + 1)),
+      "yyyy-MM-dd",
+    );
 
-  const allGames = await fetchGamesWithinDayRange(
-    today,
-    oneMonthFromToday,
-  );
+    const allGames = await fetchGamesWithinDayRange(
+      today,
+      oneMonthFromToday,
+    );
 
-  for (const game of allGames.data as (NBAGame & { datetime: string })[]) {
-    await prisma.game.upsert({
-      where: {
-        apiGameId: game.id,
-      },
-      update: {
-        homeTeam: game.home_team.name,
-        awayTeam: game.visitor_team.name,
-        startTime: new Date(game.datetime),
-        isPlayoff: game.postseason,
-      },
-      create: {
-        apiGameId: game.id,
-        homeTeam: game.home_team.name,
-        awayTeam: game.visitor_team.name,
-        startTime: new Date(game.datetime),
-        isPlayoff: game.postseason,
-      },
-    });
+    for (const game of allGames.data as (NBAGame & { datetime: string })[]) {
+      await prisma.game.upsert({
+        where: {
+          apiGameId: game.id,
+        },
+        update: {
+          homeTeam: game.home_team.name,
+          awayTeam: game.visitor_team.name,
+          startTime: new Date(game.datetime),
+          isPlayoff: game.postseason,
+        },
+        create: {
+          apiGameId: game.id,
+          homeTeam: game.home_team.name,
+          awayTeam: game.visitor_team.name,
+          startTime: new Date(game.datetime),
+          isPlayoff: game.postseason,
+        },
+      });
+    }
+  } catch (e) {
+    console.error("Failed to refresh games from API (rate limited?):", e);
   }
 }
 

--- a/actions/games.ts
+++ b/actions/games.ts
@@ -11,7 +11,7 @@ export const fetchGames = async () => {
   const today = format(new Date(), "yyyy-MM-dd");
   const allGames = await api.nba.getGames({
     // postseason: true,
-    seasons: [2024],
+    seasons: [2025],
     per_page: 100,
     start_date: today,
   });
@@ -21,7 +21,7 @@ export const fetchGames = async () => {
 
 export const fetchGamesWithinDayRange = async (startDate: string, endDate: string) => {
   const todaysGames = await api.nba.getGames({
-    seasons: [2024],
+    seasons: [2025],
     per_page: 100,
     start_date: startDate,
     end_date: endDate,
@@ -31,7 +31,7 @@ export const fetchGamesWithinDayRange = async (startDate: string, endDate: strin
 
 export const fetchGamesInSingleDay = async (date: string) => {
   const todaysGames = await api.nba.getGames({
-    seasons: [2024],
+    seasons: [2025],
     per_page: 20,
     start_date: date,
     end_date: date,

--- a/app/(protected)/pastGames/page.tsx
+++ b/app/(protected)/pastGames/page.tsx
@@ -1,13 +1,8 @@
 import { fetchFinishedGamesSince } from "@/actions/games";
-import { refreshPredictions } from "@/actions/prediction";
 
 import PastGamesSection from "@/components/Games/PastGamesSection";
-import { Game } from "@/types/IGames";
-import { NBAGame } from "@balldontlie/sdk";
 
 export default async function PredictionPage() {
-  await refreshPredictions();
-  
   const today = new Date();
   const pastOneWeek = new Date(today.setDate(today.getDate() - 7));
   const finishedGames = await fetchFinishedGamesSince(pastOneWeek);

--- a/app/(protected)/predictions/page.tsx
+++ b/app/(protected)/predictions/page.tsx
@@ -25,9 +25,18 @@ export default async function PredictionsPage() {
   await init();
 
   const today = format(new Date().toLocaleString("en-US", { timeZone: "America/New_York" }), "yyyy-MM-dd");
-  const todaysGames = await fetchGamesInSingleDay(today);
 
-  const allGames = await fetchGames(); // all games starting from 2025-04-07
+  const emptyResponse = { data: [], meta: {} };
+  let todaysGames;
+  let allGames;
+  try {
+    todaysGames = await fetchGamesInSingleDay(today);
+    allGames = await fetchGames();
+  } catch (e) {
+    console.error("Failed to fetch games from API (rate limited?):", e);
+    todaysGames = emptyResponse;
+    allGames = emptyResponse;
+  }
 
   const dbGames = await fetchAllGamesFromDb();
   const roundMap = Object.fromEntries(

--- a/app/(protected)/predictions/page.tsx
+++ b/app/(protected)/predictions/page.tsx
@@ -1,69 +1,49 @@
 
 import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 
 import PredictionsDashboard from "@/components/Predicitions/PredictionDashboard";
 import { getCurrentUserId } from "@/actions/user";
 import {
-  fetchAllGamesFromDb,
-  fetchGames,
-  fetchGamesInSingleDay,
-  refreshGamesWithinOneMonth,
-  refreshGameRounds,
+  fetchTodaysGamesFromDb,
+  fetchUpcomingGamesFromDb,
 } from "@/actions/games";
-import { fetchUsersPredictions, fetchAllPredictions, refreshPredictions } from "@/actions/prediction";
+import { fetchUsersPredictions, fetchAllPredictions } from "@/actions/prediction";
 import { PredictionMap } from "@/types/IPredictions";
-import { NBAGame } from "@balldontlie/sdk";
+import { Game } from "@/types/IGames";
 
-const init = async () => {
-  // Fetch any required data or state here
-  await refreshGamesWithinOneMonth();
-  await refreshGameRounds();
-  await refreshPredictions();
+// Convert DB game to the Game type that components expect
+function dbGameToGame(dbGame: any): Game {
+  return {
+    id: dbGame.apiGameId,
+    date: format(dbGame.startTime, "yyyy-MM-dd"),
+    datetime: dbGame.startTime.toISOString(),
+    status: dbGame.status ?? "Scheduled",
+    home_team: { name: dbGame.homeTeam },
+    home_team_score: dbGame.homeTeamScore ?? 0,
+    visitor_team: { name: dbGame.awayTeam },
+    visitor_team_score: dbGame.awayTeamScore ?? 0,
+    round: dbGame.round?.name ?? null,
+    time: "",
+  };
 }
 
-export default async function PredictionsPage() { 
-  await init();
+export default async function PredictionsPage() {
+  const today = formatInTimeZone(new Date(), "America/New_York", "yyyy-MM-dd");
 
-  const today = format(new Date().toLocaleString("en-US", { timeZone: "America/New_York" }), "yyyy-MM-dd");
+  const todaysDbGames = await fetchTodaysGamesFromDb(today);
+  const upcomingDbGames = await fetchUpcomingGamesFromDb();
 
-  const emptyResponse = { data: [], meta: {} };
-  let todaysGames;
-  let allGames;
-  try {
-    todaysGames = await fetchGamesInSingleDay(today);
-    allGames = await fetchGames();
-  } catch (e) {
-    console.error("Failed to fetch games from API (rate limited?):", e);
-    todaysGames = emptyResponse;
-    allGames = emptyResponse;
-  }
-
-  const dbGames = await fetchAllGamesFromDb();
-  const roundMap = Object.fromEntries(
-    dbGames.map((g) => [String(g.apiGameId), g.round?.name ?? null]),
-  );
-
-  const allGamesWithRound = allGames.data.map((game) => ({
-    ...game,
-    round: roundMap[String(game.id)] ?? null,
-  }));
-
-  const todayGamesWithRound = (todaysGames.data as (NBAGame & { datetime: string })[]).map((game) => ({
-    ...game,
-    round: roundMap[String(game.id)] ?? null,
-  })).sort((a, b) => {
-    const datetimeA = new Date(a.datetime);
-    const datetimeB = new Date(b.datetime);
-    return datetimeA.getTime() - datetimeB.getTime();
-  });
+  const todayGames = todaysDbGames.map(dbGameToGame);
+  const allGames = upcomingDbGames.map(dbGameToGame);
 
   const currentUserGueeses = await fetchCurrentUserGueeses();
   const allOtherUserGuesses = await fetchAllUserGuesses();
 
   return (
     <PredictionsDashboard
-      todaysGames={{ data: todayGamesWithRound, meta: todaysGames.meta ?? {} }}
-      allGames={{ data: allGamesWithRound, meta: allGames.meta ?? {} }}
+      todaysGames={{ data: todayGames, meta: {} }}
+      allGames={{ data: allGames, meta: {} }}
       currentUserGueeses={currentUserGueeses}
       allOtherGameGuesses={allOtherUserGuesses}
     />

--- a/app/api/cron/refresh-games/route.ts
+++ b/app/api/cron/refresh-games/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { refreshGamesWithinOneMonth, refreshGameRounds } from "@/actions/games";
+import { refreshPredictions } from "@/actions/prediction";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await refreshGamesWithinOneMonth();
+    await refreshGameRounds();
+    await refreshPredictions();
+
+    return NextResponse.json({ ok: true, refreshedAt: new Date().toISOString() });
+  } catch (e) {
+    console.error("Cron refresh failed:", e);
+    return NextResponse.json({ error: "Refresh failed" }, { status: 500 });
+  }
+}

--- a/auth.ts
+++ b/auth.ts
@@ -2,10 +2,5 @@ import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  providers: [
-    Google({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-  ],
+  providers: [Google],
 });

--- a/claude-implementation-plans/api-cron-refresh.md
+++ b/claude-implementation-plans/api-cron-refresh.md
@@ -1,0 +1,103 @@
+# API Data Refresh: Cron Job + Admin Manual Refresh
+
+## Problem
+当前每次用户打开 predictions 页面都会调用 Balldontlie API 3 次，导致：
+- 免费 API 频繁被限流 (429)
+- 页面加载慢（等外部 API 响应）
+- 多用户同时访问时更容易触发限流
+
+## Solution
+页面只从数据库读数据。数据刷新通过两种方式：
+1. **Vercel Cron Job** — 定时自动刷新
+2. **Admin 手动刷新按钮** — 需要时手动触发
+
+---
+
+## Task 1: 创建 API Route 用于刷新数据
+
+创建 `app/api/cron/refresh-games/route.ts`：
+- 调用 `refreshGamesWithinOneMonth()` 同步比赛日程
+- 调用 `refreshGameRounds()` 自动分配 playoff 轮次
+- 调用 `refreshPredictions()` 更新预测正确性（比赛结束后）
+- 添加 `CRON_SECRET` 环境变量验证，防止被外部随意调用
+- 返回 JSON 结果（成功/失败，刷新了多少条数据）
+
+## Task 2: 配置 Vercel Cron Job
+
+创建/更新 `vercel.json`：
+```json
+{
+  "crons": [
+    {
+      "path": "/api/cron/refresh-games",
+      "schedule": "*/30 * * * *"
+    }
+  ]
+}
+```
+- 每 30 分钟刷新一次
+- Vercel 免费版支持每天最多调用 1 次 cron（Hobby plan）
+- **注意：Vercel Hobby plan cron 最小间隔是每天 1 次。如果需要 30 分钟间隔，需要 Pro plan 或者用外部 cron 服务（如 cron-job.org）**
+
+**替代方案（如果 Hobby plan）：**
+- 设为每天刷新 1 次（`0 10 * * *`，每天上午 10 点 ET）
+- 结合 admin 手动刷新来覆盖比赛日的需求
+
+## Task 3: 修改 predictions 页面 — 只读数据库
+
+修改 `app/(protected)/predictions/page.tsx`：
+- 移除 `init()` 中的 `refreshGamesWithinOneMonth()` 调用
+- 移除直接调用 `fetchGames()` 和 `fetchGamesInSingleDay()` 
+- 改为从数据库查询今日比赛和未来比赛
+- 新增 `fetchTodaysGamesFromDb()` 和 `fetchUpcomingGamesFromDb()` 在 `actions/games.ts`
+
+改动点：
+```
+// Before (每次页面加载都调 API)
+await refreshGamesWithinOneMonth();
+const todaysGames = await fetchGamesInSingleDay(today);  // API call
+const allGames = await fetchGames();  // API call
+
+// After (只读数据库)
+const todaysGames = await fetchTodaysGamesFromDb(today);  // DB query
+const allGames = await fetchUpcomingGamesFromDb();  // DB query
+```
+
+## Task 4: Admin 页面添加手动刷新按钮
+
+在 admin 页面添加：
+- "刷新比赛数据" 按钮，调用 `refreshGamesWithinOneMonth()` + `refreshGameRounds()`
+- "刷新预测结果" 按钮，调用 `refreshPredictions()`
+- 显示 loading 状态和结果 toast
+- 只有 ADMIN 角色可以操作
+
+## Task 5: 添加 CRON_SECRET 环境变量
+
+- 生成一个随机 secret
+- 添加到 `.env` 和 Vercel 环境变量
+- cron route 里验证 `Authorization: Bearer <CRON_SECRET>`
+
+## Task 6: Past Games 页面同样改为只读 DB
+
+检查 `pastGames/page.tsx`，确保也不直接调 API。
+
+---
+
+## 数据结构注意
+
+当前 predictions 页面用的是 Balldontlie API 返回的 `NBAGame` 类型，包含 `home_team.name`、`visitor_team`、`home_team_score` 等字段。改为从 DB 读取后，数据结构是 Prisma 的 `Game` model（`homeTeam`、`awayTeam`）。
+
+**需要统一数据类型**，可能需要：
+- 调整组件 props 适配 DB 数据格式
+- 或者在查询时转换为组件期望的格式
+
+这是改动最大的部分，需要检查所有用到 `NBAGame` 类型的组件。
+
+---
+
+## Implementation Order
+1. Task 1 (API route) + Task 5 (env var)
+2. Task 3 (predictions 页面改 DB) — 这是核心改动，涉及组件类型适配
+3. Task 4 (admin 手动刷新)
+4. Task 2 (cron 配置)
+5. Task 6 (past games)

--- a/claude-implementation-plans/revive-project-2026.md
+++ b/claude-implementation-plans/revive-project-2026.md
@@ -1,0 +1,50 @@
+# Revive NBA Prediction Project for 2025-26 Season
+
+## Status
+- [x] New Supabase project created (nba-prediction-2026)
+- [x] DATABASE_URL and DIRECT_URL updated in .env
+- [x] Prisma schema updated with directUrl
+- [x] Schema pushed to new DB
+- [x] Rounds seeded
+- [x] Vercel environment variables updated
+
+## Remaining Code Fixes
+
+### 1. Season Hardcode: 2024 → 2025
+**Files to change:**
+- `actions/games.ts` — all API calls use `seasons: [2024]`, need to change to `[2025]`
+  - `fetchGames()` (line 13)
+  - `fetchGamesWithinDayRange()` (line 24)
+  - `fetchGamesInSingleDay()` (line 34)
+
+**Approach:** Replace hardcoded `2024` with `2025`. Optionally make it dynamic based on current date (if month >= October, use current year; otherwise use current year - 1). NBA seasons span two calendar years — the 2025-26 season is referenced as `2025` in the API.
+
+### 2. Auth Environment Variable Mismatch
+**File:** `auth.ts`
+- Currently uses `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+- `.env` defines `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET`
+- NextAuth v5 auto-reads `AUTH_GOOGLE_ID`/`AUTH_GOOGLE_SECRET` when no explicit config is provided
+
+**Fix:** Remove the explicit `clientId`/`clientSecret` from `auth.ts` and let NextAuth v5 auto-detect from `AUTH_GOOGLE_*` env vars. Or simply add `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` to `.env` matching the existing values.
+
+**Recommendation:** Remove explicit config — cleaner, follows NextAuth v5 convention.
+
+### 3. Seed Games for New Season
+After code fixes, run:
+```bash
+npx tsx seed/seedGames.ts
+```
+This will pull current season games from Balldontlie API into the new DB.
+
+### 4. Google OAuth Redirect URI
+**Check needed:** Verify that Google Cloud Console OAuth credentials have the correct redirect URIs for both:
+- `http://localhost:3000/api/auth/callback/google` (dev)
+- `https://your-vercel-domain.vercel.app/api/auth/callback/google` (prod)
+
+### 5. Redeploy on Vercel
+After all code fixes are committed and pushed, trigger a new deployment on Vercel.
+
+## Optional Improvements (not blocking)
+- Update Prisma from 6.5.0 to 7.x (major version, may have breaking changes)
+- Dynamic season calculation instead of hardcoded year
+- Fix `Predicitions` folder typo → `Predictions`

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 enum Role {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,17 +31,20 @@ model Round {
 }
 
 model Game {
-  id          String       @id @default(cuid())
-  apiGameId   Int          @unique // game id got from balldontlie api
-  homeTeam    String
-  awayTeam    String
-  startTime   DateTime
-  winnerTeam  String? // 比赛结果（可空）
-  round       Round?       @relation(fields: [roundId], references: [id])
-  roundId     String?
-  predictions Prediction[]
-  createdAt   DateTime     @default(now())
-  isPlayoff   Boolean?
+  id             String       @id @default(cuid())
+  apiGameId      Int          @unique // game id got from balldontlie api
+  homeTeam       String
+  awayTeam       String
+  startTime      DateTime
+  homeTeamScore  Int?
+  awayTeamScore  Int?
+  status         String       @default("Scheduled") // "Scheduled", "1st Qtr", "Halftime", "Final", etc.
+  winnerTeam     String?
+  round          Round?       @relation(fields: [roundId], references: [id])
+  roundId        String?
+  predictions    Prediction[]
+  createdAt      DateTime     @default(now())
+  isPlayoff      Boolean?
 }
 
 model Prediction {

--- a/seed/seedGames.ts
+++ b/seed/seedGames.ts
@@ -7,6 +7,13 @@ export const seedGames = async () => {
   const allGames = await fetchGames();
 
   for (const game of allGames.data as (NBAGame & { datetime: string })[]) {
+    const isFinished = game.status === "Final";
+    const winnerTeam = isFinished
+      ? game.home_team_score > game.visitor_team_score
+        ? game.home_team.name
+        : game.visitor_team.name
+      : undefined;
+
     await prisma.game.upsert({
       where: {
         apiGameId: game.id,
@@ -16,6 +23,10 @@ export const seedGames = async () => {
         awayTeam: game.visitor_team.name,
         startTime: new Date(game.datetime),
         isPlayoff: game.postseason,
+        homeTeamScore: game.home_team_score ?? null,
+        awayTeamScore: game.visitor_team_score ?? null,
+        status: isNaN(new Date(game.status).getTime()) ? game.status : "Scheduled",
+        ...(winnerTeam ? { winnerTeam } : {}),
       },
       create: {
         apiGameId: game.id,
@@ -23,6 +34,10 @@ export const seedGames = async () => {
         awayTeam: game.visitor_team.name,
         startTime: new Date(game.datetime),
         isPlayoff: game.postseason,
+        homeTeamScore: game.home_team_score ?? null,
+        awayTeamScore: game.visitor_team_score ?? null,
+        status: isNaN(new Date(game.status).getTime()) ? game.status : "Scheduled",
+        ...(winnerTeam ? { winnerTeam } : {}),
       },
     });
   }

--- a/types/IGames.ts
+++ b/types/IGames.ts
@@ -1,11 +1,12 @@
 export type Game = {
     id: number;
+    date: string;
     datetime: string;
     status: string;
     home_team: { name: string };
     home_team_score: number;
     visitor_team: { name: string };
     visitor_team_score: number;
-    round: string;
+    round: string | null;
     time: string;
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/refresh-games",
+      "schedule": "0 */6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Switch to new Supabase database (old project expired after 90 days pause)
- Update NBA API season from 2024 to 2025 for current season
- Fix NextAuth Google OAuth env variable mismatch
- Add Prisma `directUrl` for Supabase connection pooler support
- **Rewrite predictions page to read from DB instead of calling API on every page load** — eliminates rate limiting issues
- Add `/api/cron/refresh-games` endpoint with `CRON_SECRET` auth for periodic data sync
- Add game scores and status fields to DB schema
- Configure Vercel cron job (every 6 hours) to auto-refresh game data

## Test plan
- [ ] Verify predictions page loads games from DB without API calls
- [ ] Verify Google OAuth login works
- [ ] Test cron endpoint manually: `curl -H "Authorization: Bearer $CRON_SECRET" /api/cron/refresh-games`
- [ ] Verify leaderboard and past games pages still work
- [ ] Confirm Vercel deployment succeeds with new env vars