### PR TITLE
Fix scoring bug & add admin bulk game/round management

### DIFF
--- a/actions/games.ts
+++ b/actions/games.ts
@@ -145,6 +145,30 @@ export const fetchAllSortedPlayoffGamesFromDb = async () => {
   return dbGames;
 };
 
+export const fetchAllGamesWithRounds = async () => {
+  return await prisma.game.findMany({
+    orderBy: { startTime: "asc" },
+    include: { round: true },
+  });
+};
+
+export const bulkAssignGameRound = async (apiGameIds: number[], roundName: string) => {
+  const round = await prisma.round.findUnique({ where: { name: roundName } });
+  if (!round) throw new Error(`Round "${roundName}" not found`);
+
+  return await prisma.game.updateMany({
+    where: { apiGameId: { in: apiGameIds } },
+    data: { roundId: round.id },
+  });
+};
+
+export const bulkRemoveGameRound = async (apiGameIds: number[]) => {
+  return await prisma.game.updateMany({
+    where: { apiGameId: { in: apiGameIds } },
+    data: { roundId: null },
+  });
+};
+
 export const fetchFinishedGamesSince = async (date: Date) => {
   const finishedGames = await prisma.game.findMany({
     where: {

--- a/actions/games.ts
+++ b/actions/games.ts
@@ -169,6 +169,21 @@ export const bulkRemoveGameRound = async (apiGameIds: number[]) => {
   });
 };
 
+export const fetchPendingRefreshStats = async () => {
+  const now = new Date();
+
+  const [gamesWithoutWinner, unscoredPredictions] = await Promise.all([
+    prisma.game.count({
+      where: { winnerTeam: null, startTime: { lte: now } },
+    }),
+    prisma.prediction.count({
+      where: { isCorrect: null, game: { startTime: { lte: now } } },
+    }),
+  ]);
+
+  return { gamesWithoutWinner, unscoredPredictions };
+};
+
 export const fetchFinishedGamesSince = async (date: Date) => {
   const finishedGames = await prisma.game.findMany({
     where: {

--- a/actions/prediction.ts
+++ b/actions/prediction.ts
@@ -3,7 +3,7 @@
 import { prisma } from "@/lib/db";
 import { api } from "@/lib/nbaApi";
 
-import { fetchAllPendingGamesFromDb, updateGameWinnerTeam } from "./games";
+import { updateGameWinnerTeam } from "./games";
 
 interface GameParam {
   gameId: number;
@@ -69,44 +69,85 @@ export const upsertPrediction = async ({
 };
 
 export const refreshPredictions = async () => {
-  const pendingGames = await fetchAllPendingGamesFromDb();
+  const now = new Date();
 
-  for (let pendingGame of pendingGames) {
+  // Single query: all unscored predictions with their game data
+  const unscoredPredictions = await prisma.prediction.findMany({
+    where: { isCorrect: null, game: { startTime: { lte: now } } },
+    include: { game: true },
+  });
+
+  if (unscoredPredictions.length === 0) return;
+
+  // Split into two groups: games with winner already known vs unknown
+  const withWinner: { predictionId: string; predictedTeam: string; winnerTeam: string }[] = [];
+  const needsApi = new Map<string, typeof unscoredPredictions>();
+
+  for (const pred of unscoredPredictions) {
+    if (pred.game.winnerTeam) {
+      withWinner.push({
+        predictionId: pred.id,
+        predictedTeam: pred.predictedTeam,
+        winnerTeam: pred.game.winnerTeam,
+      });
+    } else {
+      const group = needsApi.get(pred.gameId) ?? [];
+      group.push(pred);
+      needsApi.set(pred.gameId, group);
+    }
+  }
+
+  // Batch 1: Bulk score predictions where winner is already known (2 queries total)
+  if (withWinner.length > 0) {
+    const correctIds = withWinner.filter((p) => p.predictedTeam === p.winnerTeam).map((p) => p.predictionId);
+    const incorrectIds = withWinner.filter((p) => p.predictedTeam !== p.winnerTeam).map((p) => p.predictionId);
+
+    await prisma.$transaction([
+      ...(correctIds.length > 0
+        ? [prisma.prediction.updateMany({ where: { id: { in: correctIds } }, data: { isCorrect: true } })]
+        : []),
+      ...(incorrectIds.length > 0
+        ? [prisma.prediction.updateMany({ where: { id: { in: incorrectIds } }, data: { isCorrect: false } })]
+        : []),
+    ]);
+
+    console.log(`Bulk scored ${withWinner.length} predictions (${correctIds.length} correct, ${incorrectIds.length} incorrect)`);
+  }
+
+  // Batch 2: Games that need API call (no winner yet) — sequential due to rate limits
+  for (const [gameId, preds] of needsApi) {
+    const game = preds[0].game;
     try {
-      const game = await api.nba.getGame(pendingGame.apiGameId);
-      if (game.data.status === "Final") {
-        const winnerTeam =
-          game.data.home_team_score > game.data.visitor_team_score
-            ? game.data.home_team.name
-            : game.data.visitor_team.name;
-  
-        await updateGameWinnerTeam(pendingGame.id, winnerTeam);
-        await upsertPredictionResult(pendingGame.id, winnerTeam);
-        console.log(`Updated game ${pendingGame.apiGameId} with winner ${winnerTeam}`);
-      }
-    }
-    catch (error) {
-      console.error(`Failed to fetch game ${pendingGame.apiGameId}:`, error);
+      const apiGame = await api.nba.getGame(game.apiGameId);
+      if (apiGame.data.status !== "Final") continue;
+
+      const winnerTeam =
+        apiGame.data.home_team_score > apiGame.data.visitor_team_score
+          ? apiGame.data.home_team.name
+          : apiGame.data.visitor_team.name;
+
+      await updateGameWinnerTeam(game.id, winnerTeam);
+
+      const correctIds = preds.filter((p) => p.predictedTeam === winnerTeam).map((p) => p.id);
+      const incorrectIds = preds.filter((p) => p.predictedTeam !== winnerTeam).map((p) => p.id);
+
+      await prisma.$transaction([
+        ...(correctIds.length > 0
+          ? [prisma.prediction.updateMany({ where: { id: { in: correctIds } }, data: { isCorrect: true } })]
+          : []),
+        ...(incorrectIds.length > 0
+          ? [prisma.prediction.updateMany({ where: { id: { in: incorrectIds } }, data: { isCorrect: false } })]
+          : []),
+      ]);
+
+      console.log(`Scored ${preds.length} predictions for game ${game.apiGameId} (winner: ${winnerTeam})`);
+    } catch (error) {
+      console.error(`Failed to process game ${game.apiGameId}:`, error);
     }
   }
 };
 
-const upsertPredictionResult = async (gameId: string, winnerTeam: string) => {
-  const predictions = await fetchPredictionsByGameId(gameId);
-
-  for (let prediction of predictions) {
-    await prisma.prediction.update({
-      where: {
-        id: prediction.id,
-      },
-      data: {
-        isCorrect: prediction.predictedTeam === winnerTeam,
-      },
-    });
-  }
-};
-
-const fetchPredictionsByGameId = async (gameId: string) => {
+export const fetchPredictionsByGameId = async (gameId: string) => {
   return await prisma.prediction.findMany({
     where: {
       gameId: gameId,

--- a/actions/rounds.ts
+++ b/actions/rounds.ts
@@ -16,3 +16,24 @@ export const updateRoundPoint = async (roundId: string, newPoint: number) => {
     data: { point: newPoint },
   });
 };
+
+export const createRound = async (name: string, point: number) => {
+  if (!name.trim()) throw new Error("Round name is required");
+  if (point <= 0) throw new Error("Point value must be greater than 0");
+
+  const existing = await prisma.round.findUnique({ where: { name: name.trim() } });
+  if (existing) throw new Error(`Round "${name}" already exists`);
+
+  return await prisma.round.create({
+    data: { name: name.trim(), point },
+  });
+};
+
+export const deleteRound = async (roundId: string) => {
+  const gamesUsingRound = await prisma.game.count({ where: { roundId } });
+  if (gamesUsingRound > 0) {
+    throw new Error(`Cannot delete: ${gamesUsingRound} game(s) are assigned to this round`);
+  }
+
+  return await prisma.round.delete({ where: { id: roundId } });
+};

--- a/actions/rounds.ts
+++ b/actions/rounds.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { prisma } from "@/lib/db";
+
+export const fetchAllRounds = async () => {
+  return await prisma.round.findMany({
+    orderBy: { point: "asc" },
+  });
+};
+
+export const updateRoundPoint = async (roundId: string, newPoint: number) => {
+  if (newPoint <= 0) throw new Error("Point value must be greater than 0");
+
+  return await prisma.round.update({
+    where: { id: roundId },
+    data: { point: newPoint },
+  });
+};

--- a/app/(protected)/admin/page.tsx
+++ b/app/(protected)/admin/page.tsx
@@ -2,11 +2,13 @@ import Link from "next/link";
 import { getCurrentUser } from "@/actions/user";
 import { refreshGamesWithinOneMonth, refreshGameRounds } from "@/actions/games";
 import { refreshPredictions } from "@/actions/prediction";
+import { fetchAllRounds } from "@/actions/rounds";
 import { Role } from "@prisma/client";
 import { Shield } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import RefreshButtons from "@/components/Admin/RefreshButtons";
+import RoundPointsManager from "@/components/Admin/RoundPointsManager";
 
 async function handleRefreshGames() {
   "use server";
@@ -33,6 +35,8 @@ export default async function AdminPage() {
     );
   }
 
+  const rounds = await fetchAllRounds();
+
   return (
     <main className="mx-auto max-w-2xl space-y-8 px-4 py-8">
       <div className="flex items-center gap-2">
@@ -45,6 +49,10 @@ export default async function AdminPage() {
           refreshGames={handleRefreshGames}
           refreshPredictions={handleRefreshPredictions}
         />
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-6">
+        <RoundPointsManager rounds={rounds} />
       </div>
     </main>
   );

--- a/app/(protected)/admin/page.tsx
+++ b/app/(protected)/admin/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { getCurrentUser } from "@/actions/user";
-import { refreshGamesWithinOneMonth, refreshGameRounds } from "@/actions/games";
+import { refreshGamesWithinOneMonth, refreshGameRounds, fetchAllGamesWithRounds } from "@/actions/games";
 import { refreshPredictions } from "@/actions/prediction";
 import { fetchAllRounds } from "@/actions/rounds";
 import { Role } from "@prisma/client";
@@ -9,6 +9,7 @@ import { Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import RefreshButtons from "@/components/Admin/RefreshButtons";
 import RoundPointsManager from "@/components/Admin/RoundPointsManager";
+import BulkGameManager from "@/components/Admin/BulkGameManager";
 
 async function handleRefreshGames() {
   "use server";
@@ -35,10 +36,13 @@ export default async function AdminPage() {
     );
   }
 
-  const rounds = await fetchAllRounds();
+  const [rounds, games] = await Promise.all([
+    fetchAllRounds(),
+    fetchAllGamesWithRounds(),
+  ]);
 
   return (
-    <main className="mx-auto max-w-2xl space-y-8 px-4 py-8">
+    <main className="mx-auto max-w-4xl space-y-8 px-4 py-8">
       <div className="flex items-center gap-2">
         <Shield className="h-6 w-6 text-primary" />
         <h1 className="text-3xl font-bold tracking-tight">Admin</h1>
@@ -53,6 +57,10 @@ export default async function AdminPage() {
 
       <div className="rounded-xl border border-border bg-card p-6">
         <RoundPointsManager rounds={rounds} />
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-6">
+        <BulkGameManager games={games} rounds={rounds} />
       </div>
     </main>
   );

--- a/app/(protected)/admin/page.tsx
+++ b/app/(protected)/admin/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { getCurrentUser } from "@/actions/user";
-import { refreshGamesWithinOneMonth, refreshGameRounds, fetchAllGamesWithRounds } from "@/actions/games";
+import { refreshGamesWithinOneMonth, refreshGameRounds, fetchAllGamesWithRounds, fetchPendingRefreshStats } from "@/actions/games";
 import { refreshPredictions } from "@/actions/prediction";
 import { fetchAllRounds } from "@/actions/rounds";
 import { Role } from "@prisma/client";
@@ -36,9 +36,10 @@ export default async function AdminPage() {
     );
   }
 
-  const [rounds, games] = await Promise.all([
+  const [rounds, games, pendingStats] = await Promise.all([
     fetchAllRounds(),
     fetchAllGamesWithRounds(),
+    fetchPendingRefreshStats(),
   ]);
 
   return (
@@ -52,6 +53,7 @@ export default async function AdminPage() {
         <RefreshButtons
           refreshGames={handleRefreshGames}
           refreshPredictions={handleRefreshPredictions}
+          pendingStats={pendingStats}
         />
       </div>
 

--- a/app/(protected)/predictions/page.tsx
+++ b/app/(protected)/predictions/page.tsx
@@ -9,6 +9,7 @@ import {
   fetchUpcomingGamesFromDb,
 } from "@/actions/games";
 import { fetchUsersPredictions, fetchAllPredictions } from "@/actions/prediction";
+import { fetchAllRounds } from "@/actions/rounds";
 import { PredictionMap } from "@/types/IPredictions";
 import { Game } from "@/types/IGames";
 
@@ -37,8 +38,11 @@ export default async function PredictionsPage() {
   const todayGames = todaysDbGames.map(dbGameToGame);
   const allGames = upcomingDbGames.map(dbGameToGame);
 
-  const currentUserGuesses = await fetchCurrentUserGuesses();
-  const allOtherUserGuesses = await fetchAllUserGuesses();
+  const [currentUserGuesses, allOtherUserGuesses, rounds] = await Promise.all([
+    fetchCurrentUserGuesses(),
+    fetchAllUserGuesses(),
+    fetchAllRounds(),
+  ]);
 
   return (
     <PredictionsDashboard
@@ -46,6 +50,7 @@ export default async function PredictionsPage() {
       allGames={allGames}
       currentUserGuesses={currentUserGuesses}
       allOtherGameGuesses={allOtherUserGuesses}
+      rounds={rounds}
     />
   );
 }

--- a/app/(protected)/rules/page.tsx
+++ b/app/(protected)/rules/page.tsx
@@ -1,9 +1,12 @@
 import { PredictionRules } from "@/components/Predicitions/PredictionRules";
+import { fetchAllRounds } from "@/actions/rounds";
 
-export default function RulePage() {
+export default async function RulePage() {
+  const rounds = await fetchAllRounds();
+
   return (
     <div className="mx-0 my-0 flex items-center justify-center">
-      <PredictionRules />
+      <PredictionRules rounds={rounds} />
     </div>
   );
 }

--- a/claude-implementation-plans/admin-bulk-games-round-management-scoring-fix.md
+++ b/claude-implementation-plans/admin-bulk-games-round-management-scoring-fix.md
@@ -1,0 +1,235 @@
+# Admin Bulk Game Management, Round Point Management & Scoring Bug Fix
+
+## Overview
+
+Three items:
+1. **Bulk Game-to-Round Management** — Admin UI to manage games in bulk (filter by date, multi-select, assign/remove rounds)
+2. **Round Points Management** — Admin UI to edit round point values (currently hardcoded in UI, seeded in DB)
+3. **Scoring Bug Fix** — Correct predictions are not awarding points on the leaderboard
+
+---
+
+## Feature 1: Bulk Game-to-Round Management
+
+### Problem
+Currently, admins must go to each individual game card on the `/predictions` page and use the `AssignRoundAndPoints` component to assign rounds one-by-one. With many games per day, this is tedious.
+
+### Solution
+Add a new section on the `/admin` page: a bulk game management panel where games are grouped by date, with multi-select and bulk round assignment/removal.
+
+### Implementation Steps
+
+#### 1.1 — New Server Action: Fetch Games Grouped by Date
+**File:** `actions/games.ts`
+
+- Add `fetchPlayoffGamesGroupedByDate()` — returns all playoff games from DB, grouped by date string (ET timezone), including their current round assignment
+- Each game object should include: `apiGameId`, `homeTeam`, `awayTeam`, `startTime`, `status`, `round` (name or null), `roundId`
+
+#### 1.2 — New Server Action: Bulk Assign Round
+**File:** `actions/games.ts`
+
+- Add `bulkAssignGameRound(gameApiIds: number[], roundName: string)` — assigns the given round to all specified games in a single transaction
+- Add `bulkRemoveGameRound(gameApiIds: number[])` — removes round assignment from all specified games
+
+#### 1.3 — New Client Component: BulkGameManager
+**File:** `components/Admin/BulkGameManager.tsx`
+
+UI design:
+- **Date filter/grouping**: Games listed under date headers (e.g., "Apr 19, 2026"), sorted chronologically
+- **Game rows**: Each row shows: checkbox | home team vs away team | time | current round badge (or "Unassigned")
+- **Selection controls**: "Select All" checkbox per date group, "Select All" global
+- **Action bar** (sticky bottom or top when selections active):
+  - Round dropdown (same options as existing: Play In, First Round, Conf Semifinals, Conf Finals, Finals) — but fetched from DB, not hardcoded
+  - "Assign Round" button — bulk assigns selected games to chosen round
+  - "Remove Round" button — bulk removes round from selected games
+- **Visual feedback**: Toast on success/error, optimistic UI update or `router.refresh()`
+
+#### 1.4 — Wire into Admin Page
+**File:** `app/(protected)/admin/page.tsx`
+
+- Fetch playoff games grouped by date (server-side)
+- Fetch rounds from DB (for the dropdown)
+- Render `BulkGameManager` below existing refresh buttons section
+- Pass server actions as props for assign/remove
+
+---
+
+## Feature 2: Round Points Management
+
+### Problem
+Round point values are seeded in the DB but also **hardcoded** in two UI locations:
+- `components/Games/AssignRoundAndPoints.tsx` (line 22-28: `ROUND_OPTIONS` array)
+- `components/Predicitions/PredictionDashboard.tsx` (line 69-74: scoring rules popover)
+
+If the admin changes point values in the DB, the UI still shows the old hardcoded values.
+
+### Solution
+1. Add an admin UI to edit round point values
+2. Make all UI components read round data from the DB instead of hardcoded values
+
+### Implementation Steps
+
+#### 2.1 — New Server Actions for Rounds
+**File:** `actions/rounds.ts` (new file)
+
+- `fetchAllRounds()` — returns all rounds with id, name, point
+- `updateRoundPoint(roundId: string, newPoint: number)` — updates the point value for a round
+
+#### 2.2 — New Client Component: RoundPointsManager
+**File:** `components/Admin/RoundPointsManager.tsx`
+
+UI design:
+- Table/list of all rounds, each row showing: round name | current point value (editable input) | save button
+- Inline editing: click to edit point value, save per-row
+- Toast feedback on save
+- Validation: point must be > 0
+
+#### 2.3 — Wire into Admin Page
+**File:** `app/(protected)/admin/page.tsx`
+
+- Fetch all rounds server-side
+- Render `RoundPointsManager` as a new card section
+
+#### 2.4 — Remove Hardcoded Round Values from UI Components
+
+**File:** `components/Games/AssignRoundAndPoints.tsx`
+- Remove the `ROUND_OPTIONS` constant
+- Accept rounds as a prop (fetched from DB by parent)
+- Or fetch rounds inside the component via server action
+
+**File:** `components/Predicitions/PredictionDashboard.tsx`
+- Remove hardcoded scoring rules in the popover (lines 69-74)
+- Accept rounds as a prop and render dynamically
+
+**File:** `app/(protected)/predictions/page.tsx`
+- Fetch rounds from DB and pass to PredictionDashboard
+
+**File:** `components/Games/TodaysGameSection.tsx` (and `AllGamesSection.tsx`)
+- Pass rounds down to `AssignRoundAndPoints` if needed
+
+---
+
+## Feature 3: Scoring Bug Fix — Leaderboard Not Updating
+
+### Root Cause Analysis
+
+**CRITICAL BUG FOUND:** There is a race condition in the refresh flow that prevents predictions from ever being scored.
+
+#### The Flow (Cron Job & Admin Refresh):
+```
+1. refreshGamesWithinOneMonth()  →  Sets winnerTeam for finished games
+2. refreshGameRounds()           →  Assigns rounds
+3. refreshPredictions()          →  Looks for games WHERE winnerTeam IS NULL
+```
+
+#### The Problem:
+- Step 1 (`refreshGamesWithinOneMonth`) at `actions/games.ts:183-201` already sets `winnerTeam` for any game with `status === "Final"`:
+  ```typescript
+  const winnerTeam = isFinished
+    ? game.home_team_score > game.visitor_team_score
+      ? game.home_team.name
+      : game.visitor_team.name
+    : undefined;
+  // ... upsert with ...(winnerTeam ? { winnerTeam } : {})
+  ```
+
+- Step 3 (`refreshPredictions`) calls `fetchAllPendingGamesFromDb()` at `actions/games.ts:117-126` which filters:
+  ```typescript
+  where: {
+    winnerTeam: null,  // <-- These games already have winnerTeam set from Step 1!
+    startTime: { lte: new Date(Date.now()) }
+  }
+  ```
+
+- **Result:** `refreshPredictions()` finds ZERO pending games because Step 1 already set the `winnerTeam`. Predictions are never scored (`isCorrect` remains `null`). The leaderboard only counts predictions where `isCorrect === true`, so all points are 0.
+
+#### Secondary Issue: Games Without Rounds
+Even after fixing the scoring, `getLeaderboard()` uses `prediction?.game?.round?.point ?? 0`. If a correctly predicted game has no round assigned, it contributes 0 points. This is technically "by design" (only playoff rounds earn points), but worth noting.
+
+### Fix Options
+
+#### Option A: Separate the concerns (Recommended)
+Change `refreshPredictions()` to NOT depend on `winnerTeam` being null. Instead:
+
+1. Find predictions where `isCorrect IS NULL` and the game has started
+2. For each such prediction, check if the game already has a `winnerTeam` in the DB
+3. If yes, score the prediction directly without re-fetching from API
+4. If no, fetch from API, update the game, then score
+
+**Implementation:**
+
+**File:** `actions/prediction.ts` — Rewrite `refreshPredictions()`:
+```typescript
+export const refreshPredictions = async () => {
+  // Find all predictions that haven't been scored yet
+  const unscoredPredictions = await prisma.prediction.findMany({
+    where: { isCorrect: null },
+    include: { game: true },
+  });
+
+  // Group by game to avoid duplicate API calls
+  const gameIds = [...new Set(unscoredPredictions.map(p => p.gameId))];
+  
+  for (const gameId of gameIds) {
+    const game = await prisma.game.findUnique({ where: { id: gameId } });
+    if (!game || game.startTime > new Date()) continue;
+
+    let winnerTeam = game.winnerTeam;
+
+    // If winner not yet determined, try fetching from API
+    if (!winnerTeam) {
+      try {
+        const apiGame = await api.nba.getGame(game.apiGameId);
+        if (apiGame.data.status === "Final") {
+          winnerTeam = apiGame.data.home_team_score > apiGame.data.visitor_team_score
+            ? apiGame.data.home_team.name
+            : apiGame.data.visitor_team.name;
+          await updateGameWinnerTeam(game.id, winnerTeam);
+        }
+      } catch (error) {
+        console.error(`Failed to fetch game ${game.apiGameId}:`, error);
+        continue;
+      }
+    }
+
+    // Score predictions for this game
+    if (winnerTeam) {
+      await upsertPredictionResult(gameId, winnerTeam);
+    }
+  }
+};
+```
+
+**File:** `actions/games.ts` — `fetchAllPendingGamesFromDb()` can remain as-is (only used by refreshPredictions which we're rewriting), but consider removing it if no longer needed.
+
+#### Option B: Quick fix — Don't set winnerTeam in refreshGamesWithinOneMonth
+Remove the `winnerTeam` logic from `refreshGamesWithinOneMonth()` and let `refreshPredictions()` be the sole owner of setting `winnerTeam`. This is simpler but less robust — the game data would be incomplete until predictions are refreshed.
+
+**Recommendation:** Option A is more robust and also handles edge cases like manually-triggered partial refreshes.
+
+### Fix Step: Backfill Existing Unscored Predictions
+After deploying the fix, existing predictions with `isCorrect: null` on finished games need to be scored. The rewritten `refreshPredictions()` will handle this automatically on the next run, since it looks for `isCorrect: null` instead of `winnerTeam: null`.
+
+---
+
+## Implementation Order
+
+1. **Fix the scoring bug first** (Feature 3) — this is a production bug affecting all users
+2. **Round points management** (Feature 2) — small, self-contained
+3. **Bulk game management** (Feature 1) — largest feature, builds on top of dynamic round data from Feature 2
+
+## Files Changed Summary
+
+| File | Changes |
+|------|---------|
+| `actions/prediction.ts` | Rewrite `refreshPredictions()` to find unscored predictions |
+| `actions/games.ts` | Add `fetchPlayoffGamesGroupedByDate()`, `bulkAssignGameRound()`, `bulkRemoveGameRound()` |
+| `actions/rounds.ts` (new) | `fetchAllRounds()`, `updateRoundPoint()` |
+| `components/Admin/BulkGameManager.tsx` (new) | Bulk game-to-round management UI |
+| `components/Admin/RoundPointsManager.tsx` (new) | Round points editing UI |
+| `app/(protected)/admin/page.tsx` | Add new admin sections, fetch rounds & games |
+| `components/Games/AssignRoundAndPoints.tsx` | Remove hardcoded `ROUND_OPTIONS`, use DB rounds |
+| `components/Predicitions/PredictionDashboard.tsx` | Remove hardcoded scoring rules, use DB rounds |
+| `app/(protected)/predictions/page.tsx` | Fetch and pass rounds to dashboard |
+| `components/Games/TodaysGameSection.tsx` | Pass rounds to AssignRoundAndPoints |
+| `components/Games/AllGamesSection.tsx` | Pass rounds to AssignRoundAndPoints (if used) |

--- a/components/Admin/BulkGameManager.tsx
+++ b/components/Admin/BulkGameManager.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { bulkAssignGameRound, bulkRemoveGameRound } from "@/actions/games";
+import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
+import { toast } from "sonner";
+import { CalendarDays, Check, Minus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type Round = {
+  id: string;
+  name: string;
+  point: number;
+};
+
+type Game = {
+  apiGameId: number;
+  homeTeam: string;
+  awayTeam: string;
+  startTime: Date;
+  status: string;
+  round: Round | null;
+};
+
+type Props = {
+  games: Game[];
+  rounds: Round[];
+};
+
+type GroupedGames = Record<string, Game[]>;
+
+function groupByDate(games: Game[]): GroupedGames {
+  return games.reduce((groups: GroupedGames, game) => {
+    const date = formatInTimeZone(game.startTime, "America/New_York", "yyyy-MM-dd");
+    if (!groups[date]) groups[date] = [];
+    groups[date].push(game);
+    return groups;
+  }, {});
+}
+
+export default function BulkGameManager({ games, rounds }: Props) {
+  const router = useRouter();
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [selectedRound, setSelectedRound] = useState(rounds[0]?.name ?? "");
+  const [loading, setLoading] = useState(false);
+
+  const grouped = groupByDate(games);
+  const dateKeys = Object.keys(grouped).sort();
+
+  const toggleGame = (apiGameId: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(apiGameId)) next.delete(apiGameId);
+      else next.add(apiGameId);
+      return next;
+    });
+  };
+
+  const toggleDate = (date: string) => {
+    const dateGames = grouped[date];
+    const allSelected = dateGames.every((g) => selected.has(g.apiGameId));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const g of dateGames) {
+        if (allSelected) next.delete(g.apiGameId);
+        else next.add(g.apiGameId);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    const allSelected = games.every((g) => selected.has(g.apiGameId));
+    if (allSelected) setSelected(new Set());
+    else setSelected(new Set(games.map((g) => g.apiGameId)));
+  };
+
+  const handleAssign = async () => {
+    if (selected.size === 0) return;
+    setLoading(true);
+    try {
+      await bulkAssignGameRound([...selected], selectedRound);
+      toast.success(`Assigned ${selected.size} games to ${selectedRound}`);
+      setSelected(new Set());
+      router.refresh();
+    } catch {
+      toast.error("Failed to assign round");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (selected.size === 0) return;
+    setLoading(true);
+    try {
+      await bulkRemoveGameRound([...selected]);
+      toast.success(`Removed round from ${selected.size} games`);
+      setSelected(new Set());
+      router.refresh();
+    } catch {
+      toast.error("Failed to remove round");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <CalendarDays className="h-5 w-5 text-primary" />
+        <h2 className="text-lg font-semibold">Bulk Game Management</h2>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          {games.length} games
+        </span>
+      </div>
+
+      {/* Action bar */}
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/50 p-3">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            checked={games.length > 0 && games.every((g) => selected.has(g.apiGameId))}
+            onCheckedChange={toggleAll}
+          />
+          <span className="text-sm text-muted-foreground">
+            {selected.size > 0 ? `${selected.size} selected` : "Select all"}
+          </span>
+        </div>
+
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <Select value={selectedRound} onValueChange={setSelectedRound}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Select round" />
+            </SelectTrigger>
+            <SelectContent>
+              {rounds.map((r) => (
+                <SelectItem key={r.name} value={r.name}>
+                  {r.name} ({r.point} pts)
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Button
+            size="sm"
+            disabled={selected.size === 0 || loading}
+            onClick={handleAssign}
+          >
+            <Check className="mr-1 h-3.5 w-3.5" />
+            Assign
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            disabled={selected.size === 0 || loading}
+            onClick={handleRemove}
+          >
+            <Minus className="mr-1 h-3.5 w-3.5" />
+            Remove
+          </Button>
+        </div>
+      </div>
+
+      {/* Game list grouped by date */}
+      <div className="max-h-[600px] space-y-4 overflow-y-auto">
+        {dateKeys.map((date) => {
+          const dateGames = grouped[date];
+          const allDateSelected = dateGames.every((g) => selected.has(g.apiGameId));
+          const someDateSelected = dateGames.some((g) => selected.has(g.apiGameId));
+
+          return (
+            <div key={date} className="space-y-1">
+              {/* Date header */}
+              <div className="flex items-center gap-2 py-1">
+                <Checkbox
+                  checked={allDateSelected}
+                  className={!allDateSelected && someDateSelected ? "opacity-50" : ""}
+                  onCheckedChange={() => toggleDate(date)}
+                />
+                <span className="text-sm font-semibold">
+                  {format(new Date(date + "T12:00:00"), "EEE, MMM d, yyyy")}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {dateGames.length} game{dateGames.length > 1 ? "s" : ""}
+                </span>
+              </div>
+
+              {/* Games */}
+              <div className="space-y-1 pl-6">
+                {dateGames.map((game) => (
+                  <label
+                    key={game.apiGameId}
+                    className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50"
+                  >
+                    <Checkbox
+                      checked={selected.has(game.apiGameId)}
+                      onCheckedChange={() => toggleGame(game.apiGameId)}
+                    />
+                    <span className="flex-1 text-sm">
+                      {game.homeTeam} vs {game.awayTeam}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatInTimeZone(game.startTime, "America/New_York", "h:mm a")}
+                    </span>
+                    {game.round ? (
+                      <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                        {game.round.name}
+                      </span>
+                    ) : (
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        Unassigned
+                      </span>
+                    )}
+                  </label>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/Admin/RefreshButtons.tsx
+++ b/components/Admin/RefreshButtons.tsx
@@ -31,16 +31,38 @@ function RefreshButton({ label, action }: RefreshButtonProps) {
   );
 }
 
+type PendingStats = {
+  gamesWithoutWinner: number;
+  unscoredPredictions: number;
+};
+
 export default function RefreshButtons({
   refreshGames,
   refreshPredictions,
+  pendingStats,
 }: {
   refreshGames: () => Promise<void>;
   refreshPredictions: () => Promise<void>;
+  pendingStats: PendingStats;
 }) {
+  const { gamesWithoutWinner, unscoredPredictions } = pendingStats;
+  const hasPending = gamesWithoutWinner > 0 || unscoredPredictions > 0;
+
   return (
     <div className="flex flex-col gap-4">
       <h2 className="text-xl font-semibold">Data Refresh</h2>
+
+      {hasPending && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-300">
+          {gamesWithoutWinner > 0 && (
+            <p>{gamesWithoutWinner} started game{gamesWithoutWinner > 1 ? "s" : ""} without results</p>
+          )}
+          {unscoredPredictions > 0 && (
+            <p>{unscoredPredictions} prediction{unscoredPredictions > 1 ? "s" : ""} not yet scored</p>
+          )}
+        </div>
+      )}
+
       <div className="flex flex-col gap-3 sm:flex-row">
         <RefreshButton label="Refresh Games & Rounds" action={refreshGames} />
         <RefreshButton label="Refresh Predictions" action={refreshPredictions} />

--- a/components/Admin/RoundPointsManager.tsx
+++ b/components/Admin/RoundPointsManager.tsx
@@ -15,18 +15,18 @@ type Round = {
 };
 
 export default function RoundPointsManager({ rounds }: { rounds: Round[] }) {
-  const [values, setValues] = useState<Record<string, number>>(
-    Object.fromEntries(rounds.map((r) => [r.id, r.point])),
+  const [values, setValues] = useState<Record<string, string>>(
+    Object.fromEntries(rounds.map((r) => [r.id, String(r.point)])),
   );
   const [saving, setSaving] = useState<string | null>(null);
 
   const handleSave = async (round: Round) => {
-    const newPoint = values[round.id];
-    if (newPoint === round.point) return;
-    if (newPoint <= 0) {
+    const newPoint = parseFloat(values[round.id]);
+    if (isNaN(newPoint) || newPoint <= 0) {
       toast.error("Point value must be greater than 0");
       return;
     }
+    if (newPoint === round.point) return;
 
     setSaving(round.id);
     try {
@@ -59,7 +59,7 @@ export default function RoundPointsManager({ rounds }: { rounds: Round[] }) {
               min={0.5}
               value={values[round.id]}
               onChange={(e) =>
-                setValues((prev) => ({ ...prev, [round.id]: Number(e.target.value) }))
+                setValues((prev) => ({ ...prev, [round.id]: e.target.value }))
               }
               className="w-24"
             />
@@ -67,7 +67,7 @@ export default function RoundPointsManager({ rounds }: { rounds: Round[] }) {
             <Button
               size="sm"
               variant="outline"
-              disabled={saving === round.id || values[round.id] === round.point}
+              disabled={saving === round.id || parseFloat(values[round.id]) === round.point || values[round.id] === ""}
               onClick={() => handleSave(round)}
             >
               <Save className="mr-1 h-3.5 w-3.5" />

--- a/components/Admin/RoundPointsManager.tsx
+++ b/components/Admin/RoundPointsManager.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { updateRoundPoint } from "@/actions/rounds";
+import { useRouter } from "next/navigation";
+import { updateRoundPoint, createRound, deleteRound } from "@/actions/rounds";
 import { toast } from "sonner";
-import { Save, Trophy } from "lucide-react";
+import { Plus, Save, Trophy } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import DestructiveModal from "@/components/destructive-modal";
 
 type Round = {
   id: string;
@@ -15,27 +17,67 @@ type Round = {
 };
 
 export default function RoundPointsManager({ rounds }: { rounds: Round[] }) {
+  const router = useRouter();
   const [values, setValues] = useState<Record<string, string>>(
     Object.fromEntries(rounds.map((r) => [r.id, String(r.point)])),
   );
   const [saving, setSaving] = useState<string | null>(null);
+  const [newName, setNewName] = useState("");
+  const [newPoint, setNewPoint] = useState("");
+  const [adding, setAdding] = useState(false);
 
   const handleSave = async (round: Round) => {
-    const newPoint = parseFloat(values[round.id]);
-    if (isNaN(newPoint) || newPoint <= 0) {
+    const point = parseFloat(values[round.id]);
+    if (isNaN(point) || point <= 0) {
       toast.error("Point value must be greater than 0");
       return;
     }
-    if (newPoint === round.point) return;
+    if (point === round.point) return;
 
     setSaving(round.id);
     try {
-      await updateRoundPoint(round.id, newPoint);
-      toast.success(`Updated ${round.name} to ${newPoint} pts`);
+      await updateRoundPoint(round.id, point);
+      toast.success(`Updated ${round.name} to ${point} pts`);
+      router.refresh();
     } catch {
       toast.error(`Failed to update ${round.name}`);
     } finally {
       setSaving(null);
+    }
+  };
+
+  const handleAdd = async () => {
+    const point = parseFloat(newPoint);
+    if (!newName.trim()) {
+      toast.error("Round name is required");
+      return;
+    }
+    if (isNaN(point) || point <= 0) {
+      toast.error("Point value must be greater than 0");
+      return;
+    }
+
+    setAdding(true);
+    try {
+      await createRound(newName, point);
+      toast.success(`Created round "${newName}" (${point} pts)`);
+      setNewName("");
+      setNewPoint("");
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to create round");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleDelete = async (round: Round) => {
+    try {
+      await deleteRound(round.id);
+      toast.success(`Deleted "${round.name}"`);
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete round");
     }
   };
 
@@ -46,13 +88,14 @@ export default function RoundPointsManager({ rounds }: { rounds: Round[] }) {
         <h2 className="text-lg font-semibold">Round Points</h2>
       </div>
 
+      {/* Existing rounds */}
       <div className="space-y-3">
         {rounds.map((round) => (
           <div
             key={round.id}
             className="flex items-center gap-3 rounded-lg border border-border bg-background p-3"
           >
-            <span className="min-w-[180px] text-sm font-medium">{round.name}</span>
+            <span className="min-w-[140px] text-sm font-medium sm:min-w-[180px]">{round.name}</span>
             <Input
               type="number"
               step="0.5"
@@ -73,8 +116,42 @@ export default function RoundPointsManager({ rounds }: { rounds: Round[] }) {
               <Save className="mr-1 h-3.5 w-3.5" />
               {saving === round.id ? "Saving..." : "Save"}
             </Button>
+            <DestructiveModal
+              btnTitle=""
+              title={`Delete "${round.name}"`}
+              description="This will permanently delete this round. Games currently assigned to it must be unassigned first."
+              handler={() => handleDelete(round)}
+              variant="ghost"
+            />
           </div>
         ))}
+      </div>
+
+      {/* Add new round */}
+      <div className="flex items-center gap-3 rounded-lg border border-dashed border-border bg-muted/30 p-3">
+        <Input
+          placeholder="Round name"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          className="min-w-[140px] sm:min-w-[180px]"
+        />
+        <Input
+          type="number"
+          step="0.5"
+          min={0.5}
+          placeholder="Pts"
+          value={newPoint}
+          onChange={(e) => setNewPoint(e.target.value)}
+          className="w-24"
+        />
+        <Button
+          size="sm"
+          disabled={adding || !newName.trim() || !newPoint}
+          onClick={handleAdd}
+        >
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          {adding ? "Adding..." : "Add"}
+        </Button>
       </div>
     </div>
   );

--- a/components/Admin/RoundPointsManager.tsx
+++ b/components/Admin/RoundPointsManager.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { updateRoundPoint } from "@/actions/rounds";
+import { toast } from "sonner";
+import { Save, Trophy } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type Round = {
+  id: string;
+  name: string;
+  point: number;
+};
+
+export default function RoundPointsManager({ rounds }: { rounds: Round[] }) {
+  const [values, setValues] = useState<Record<string, number>>(
+    Object.fromEntries(rounds.map((r) => [r.id, r.point])),
+  );
+  const [saving, setSaving] = useState<string | null>(null);
+
+  const handleSave = async (round: Round) => {
+    const newPoint = values[round.id];
+    if (newPoint === round.point) return;
+    if (newPoint <= 0) {
+      toast.error("Point value must be greater than 0");
+      return;
+    }
+
+    setSaving(round.id);
+    try {
+      await updateRoundPoint(round.id, newPoint);
+      toast.success(`Updated ${round.name} to ${newPoint} pts`);
+    } catch {
+      toast.error(`Failed to update ${round.name}`);
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Trophy className="h-5 w-5 text-primary" />
+        <h2 className="text-lg font-semibold">Round Points</h2>
+      </div>
+
+      <div className="space-y-3">
+        {rounds.map((round) => (
+          <div
+            key={round.id}
+            className="flex items-center gap-3 rounded-lg border border-border bg-background p-3"
+          >
+            <span className="min-w-[180px] text-sm font-medium">{round.name}</span>
+            <Input
+              type="number"
+              step="0.5"
+              min={0.5}
+              value={values[round.id]}
+              onChange={(e) =>
+                setValues((prev) => ({ ...prev, [round.id]: Number(e.target.value) }))
+              }
+              className="w-24"
+            />
+            <span className="text-sm text-muted-foreground">pts</span>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={saving === round.id || values[round.id] === round.point}
+              onClick={() => handleSave(round)}
+            >
+              <Save className="mr-1 h-3.5 w-3.5" />
+              {saving === round.id ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/Games/AllGamesSection.tsx
+++ b/components/Games/AllGamesSection.tsx
@@ -11,10 +11,16 @@ import { AssignRoundAndPoints } from "@/components/Games/AssignRoundAndPoints";
 import { Game } from "@/types/IGames";
 import { GameCard } from "../Predicitions/GameCard";
 
+type RoundOption = {
+  name: string;
+  point: number;
+};
+
 type Props = {
   games: Game[];
   guesses: Record<string, string>;
   onGuess: (gameApiId: number, team: string) => void;
+  rounds: RoundOption[];
 };
 
 type GroupedGames = Record<string, Game[]>;
@@ -23,6 +29,7 @@ export default function AllGamesSection({
   games,
   onGuess,
   guesses,
+  rounds,
 }: Props) {
   const [visibleDates, setVisibleDates] = useState(3);
 
@@ -82,6 +89,7 @@ export default function AllGamesSection({
                   />
                   <AssignRoundAndPoints
                     gameId={game.id}
+                    rounds={rounds}
                     onSubmit={(gameId, round) =>
                       handleAssignRound(gameId as number, round)
                     }

--- a/components/Games/AssignRoundAndPoints.tsx
+++ b/components/Games/AssignRoundAndPoints.tsx
@@ -19,22 +19,21 @@ import {
 } from "@/components/ui/select";
 import DestructiveModal from "@/components/destructive-modal";
 
-const ROUND_OPTIONS = [
-  { label: "Play In", value: "Play In", point: 1 },
-  { label: "First Round", value: "First Round", point: 1.5 },
-  { label: "Conference Semifinals", value: "Conference Semifinals", point: 2 },
-  { label: "Conference Finals", value: "Conference Finals", point: 3 },
-  { label: "Finals", value: "Finals", point: 5 },
-];
+type RoundOption = {
+  name: string;
+  point: number;
+};
+
 type AssignProps = {
   gameId: number;
+  rounds: RoundOption[];
   onSubmit: (gameId: string | number, round: string) => Promise<void>;
 };
 
-export const AssignRoundAndPoints = ({ gameId, onSubmit }: AssignProps) => {
+export const AssignRoundAndPoints = ({ gameId, rounds, onSubmit }: AssignProps) => {
   const user = useUser();
-  const [selectedRound, setSelectedRound] = useState(ROUND_OPTIONS[0].value);
-  const [point, setPoint] = useState(ROUND_OPTIONS[0].point);
+  const [selectedRound, setSelectedRound] = useState(rounds[0]?.name ?? "");
+  const [point, setPoint] = useState(rounds[0]?.point ?? 0);
   const [loading, setLoading] = useState<boolean>(false);
 
   const router = useRouter();
@@ -71,7 +70,7 @@ export const AssignRoundAndPoints = ({ gameId, onSubmit }: AssignProps) => {
           value={selectedRound}
           onValueChange={(value) => {
             setSelectedRound(value);
-            const option = ROUND_OPTIONS.find((r) => r.value === value);
+            const option = rounds.find((r) => r.name === value);
             if (option) setPoint(option.point);
           }}
         >
@@ -79,13 +78,11 @@ export const AssignRoundAndPoints = ({ gameId, onSubmit }: AssignProps) => {
             <SelectValue placeholder="Select round" />
           </SelectTrigger>
           <SelectContent>
-            <>
-              {ROUND_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </>
+            {rounds.map((option) => (
+              <SelectItem key={option.name} value={option.name}>
+                {option.name}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
 

--- a/components/Games/TodaysGameSection.tsx
+++ b/components/Games/TodaysGameSection.tsx
@@ -11,14 +11,20 @@ import { Game } from "@/types/IGames";
 import { PredictionMap } from "@/types/IPredictions";
 import { GameCard } from "../Predicitions/GameCard";
 
+type RoundOption = {
+  name: string;
+  point: number;
+};
+
 type Props = {
   games: Game[];
   guesses: Record<string, string>;
   onGuess: (gameApiId: number, team: string) => void;
   allOtherGameGuesses: PredictionMap;
+  rounds: RoundOption[];
 };
 
-export default function TodaysGamesSection({ games, guesses, onGuess, allOtherGameGuesses }: Props) {
+export default function TodaysGamesSection({ games, guesses, onGuess, allOtherGameGuesses, rounds }: Props) {
   const handleAssignRound = async (gameApiId: number, roundName: string) => {
     try {
       await assignGameToRound(gameApiId, roundName);
@@ -57,6 +63,7 @@ export default function TodaysGamesSection({ games, guesses, onGuess, allOtherGa
               />
               <AssignRoundAndPoints
                 gameId={game.id}
+                rounds={rounds}
                 onSubmit={(gameId, round) =>
                   handleAssignRound(gameId as number, round)
                 }

--- a/components/Predicitions/PredictionDashboard.tsx
+++ b/components/Predicitions/PredictionDashboard.tsx
@@ -17,11 +17,17 @@ import TodaysGamesSection from "@/components/Games/TodaysGameSection";
 import { Game } from "@/types/IGames";
 import { PredictionMap } from "@/types/IPredictions";
 
+type RoundOption = {
+  name: string;
+  point: number;
+};
+
 type PredictionsDashboardProps = {
   todaysGames: Game[];
   allGames: Game[];
   currentUserGuesses: Record<number, string>;
   allOtherGameGuesses: PredictionMap;
+  rounds: RoundOption[];
 };
 
 export default function PredictionsDashboard({
@@ -29,6 +35,7 @@ export default function PredictionsDashboard({
   allGames,
   currentUserGuesses,
   allOtherGameGuesses,
+  rounds,
 }: PredictionsDashboardProps) {
   const [guesses, setGuesses] = useState<Record<number, string>>(currentUserGuesses);
 
@@ -66,11 +73,12 @@ export default function PredictionsDashboard({
           <div className="space-y-2">
             <h4 className="text-sm font-semibold">Scoring Rules</h4>
             <ul className="space-y-1.5 text-sm text-muted-foreground">
-              <li className="flex justify-between"><span>Play In</span><span className="font-medium text-foreground">1 pt</span></li>
-              <li className="flex justify-between"><span>First Round</span><span className="font-medium text-foreground">1.5 pts</span></li>
-              <li className="flex justify-between"><span>Conf. Semifinals</span><span className="font-medium text-foreground">2 pts</span></li>
-              <li className="flex justify-between"><span>Conf. Finals</span><span className="font-medium text-foreground">3 pts</span></li>
-              <li className="flex justify-between"><span>Finals</span><span className="font-medium text-foreground">5 pts</span></li>
+              {rounds.map((round) => (
+                <li key={round.name} className="flex justify-between">
+                  <span>{round.name}</span>
+                  <span className="font-medium text-foreground">{round.point} {round.point === 1 ? "pt" : "pts"}</span>
+                </li>
+              ))}
             </ul>
             <p className="text-xs text-muted-foreground">Predictions lock when the game starts.</p>
           </div>
@@ -83,6 +91,7 @@ export default function PredictionsDashboard({
         guesses={guesses}
         onGuess={handleGuess}
         allOtherGameGuesses={allOtherGameGuesses}
+        rounds={rounds}
       />
 
       {/* Upcoming Games */}
@@ -91,6 +100,7 @@ export default function PredictionsDashboard({
           games={allGames}
           guesses={guesses}
           onGuess={handleGuess}
+          rounds={rounds}
         />
       )}
     </main>

--- a/components/Predicitions/PredictionRules.tsx
+++ b/components/Predicitions/PredictionRules.tsx
@@ -1,15 +1,16 @@
-// components/predictions/PredictionRules.tsx
+type Round = {
+  name: string;
+  point: number;
+};
 
-export const PredictionRules = () => {
+export const PredictionRules = ({ rounds }: { rounds: Round[] }) => {
   return (
     <section className="mt-8 text-sm text-muted-foreground sm:text-base">
       <h3 className="mb-2 text-base font-semibold sm:text-lg">📜 竞猜规则：</h3>
       <ul className="list-disc space-y-1 pl-4 sm:pl-6">
-        <li>猜对 Play In：1分</li>
-        <li>猜对 First Round：1.5分</li>
-        <li>猜对 Conference Semifinals：2分</li>
-        <li>猜对 Conference Finals：3分</li>
-        <li>猜对 Finals：5分</li>
+        {rounds.map((round) => (
+          <li key={round.name}>猜对 {round.name}：{round.point}分</li>
+        ))}
         <li>比赛开始后无法再竞猜</li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- **Fix scoring bug**: `refreshPredictions()` was finding zero games to score because `refreshGamesWithinOneMonth()` already set `winnerTeam`, causing a race condition. Rewritten to find unscored predictions (`isCorrect: null`) and batch score them.
- **Admin round points management**: Add/edit/delete rounds with point values from admin page. Removed all hardcoded round values from UI components.
- **Admin bulk game management**: Games grouped by date with multi-select, bulk assign/remove round.
- **Pending refresh stats**: Amber warning banner showing unscored predictions and games without results.

## Test plan
- [ ] Go to `/admin` and click "Refresh Games & Rounds" — verify previously unscored predictions get scored
- [ ] Check `/leaderboard` — verify correct predictions now show points
- [ ] Edit a round's point value on admin page — verify leaderboard updates accordingly
- [ ] Add a new round (e.g. "Regular Season") and delete it
- [ ] Try deleting a round that has games assigned — verify it blocks with error
- [ ] Select multiple games by date, bulk assign a round, verify round badges update
- [ ] Verify scoring rules popover on `/predictions` and `/rules` page show dynamic values