### PR TITLE
feat: add unbid game reminder system

### DIFF
--- a/actions/prediction.ts
+++ b/actions/prediction.ts
@@ -170,6 +170,29 @@ export const fetchUsersPredictions = async (userId: string) => {
   });
 }
 
+export const fetchTodaysUnbidGames = async (
+  userId: string,
+  todayStr: string,
+) => {
+  const startOfDay = new Date(`${todayStr}T00:00:00-04:00`);
+  const endOfDay = new Date(`${todayStr}T23:59:59.999-04:00`);
+
+  return await prisma.game.findMany({
+    where: {
+      startTime: {
+        gte: startOfDay,
+        lte: endOfDay,
+        gt: new Date(),
+      },
+      predictions: {
+        none: { userId },
+      },
+    },
+    include: { round: true },
+    orderBy: { startTime: "asc" },
+  });
+};
+
 export const fetchAllPredictions = async () => {
   return await prisma.prediction.findMany({
     include: {

--- a/actions/user.ts
+++ b/actions/user.ts
@@ -30,6 +30,16 @@ export const createUserIfNotExists = async (user: UserData): Promise<void> => {
   }
 };
 
+export const updateEmailReminders = async (
+  userId: string,
+  enabled: boolean,
+) => {
+  await prisma.user.update({
+    where: { id: userId },
+    data: { emailReminders: enabled },
+  });
+};
+
 export const getCurrentUser = async () => {
   const session = await auth();
   if (!session?.user?.email) return null;

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -21,7 +21,12 @@ const ProtectedLayout = async ({ children }: { children: ReactNode }) => {
 
   return (
     <div>
-      <NavBar session={session} isAdmin={user?.role === Role.ADMIN} />
+      <NavBar
+        session={session}
+        isAdmin={user?.role === Role.ADMIN}
+        userId={user?.id ?? ""}
+        emailReminders={user?.emailReminders ?? true}
+      />
       {children}
     </div>
   );

--- a/app/(protected)/predictions/page.tsx
+++ b/app/(protected)/predictions/page.tsx
@@ -8,7 +8,11 @@ import {
   fetchTodaysGamesFromDb,
   fetchUpcomingGamesFromDb,
 } from "@/actions/games";
-import { fetchUsersPredictions, fetchAllPredictions } from "@/actions/prediction";
+import {
+  fetchUsersPredictions,
+  fetchAllPredictions,
+  fetchTodaysUnbidGames,
+} from "@/actions/prediction";
 import { fetchAllRounds } from "@/actions/rounds";
 import { PredictionMap } from "@/types/IPredictions";
 import { Game } from "@/types/IGames";
@@ -38,11 +42,17 @@ export default async function PredictionsPage() {
   const todayGames = todaysDbGames.map(dbGameToGame);
   const allGames = upcomingDbGames.map(dbGameToGame);
 
-  const [currentUserGuesses, allOtherUserGuesses, rounds] = await Promise.all([
-    fetchCurrentUserGuesses(),
-    fetchAllUserGuesses(),
-    fetchAllRounds(),
-  ]);
+  const userId = await getCurrentUserId();
+
+  const [currentUserGuesses, allOtherUserGuesses, rounds, unbidDbGames] =
+    await Promise.all([
+      fetchCurrentUserGuesses(userId),
+      fetchAllUserGuesses(userId),
+      fetchAllRounds(),
+      fetchTodaysUnbidGames(userId, today),
+    ]);
+
+  const unbidGames = unbidDbGames.map(dbGameToGame);
 
   return (
     <PredictionsDashboard
@@ -51,23 +61,22 @@ export default async function PredictionsPage() {
       currentUserGuesses={currentUserGuesses}
       allOtherGameGuesses={allOtherUserGuesses}
       rounds={rounds}
+      unbidGames={unbidGames}
     />
   );
 }
 
 
-const fetchCurrentUserGuesses = async () => {
-  const userId = await getCurrentUserId();
+const fetchCurrentUserGuesses = async (userId: string) => {
   const currentUserPredictions = await fetchUsersPredictions(userId);
   const currentUserGuesses = Object.fromEntries(
     currentUserPredictions.map((p) => [p.game.apiGameId, p.predictedTeam]),
   );
 
   return currentUserGuesses;
-}
+};
 
-const fetchAllUserGuesses = async () => {
-  const currentUserId = await getCurrentUserId();
+const fetchAllUserGuesses = async (currentUserId: string) => {
   const allPredictions = await fetchAllPredictions();
   const groupedPredictions: PredictionMap = {};
 
@@ -76,9 +85,12 @@ const fetchAllUserGuesses = async () => {
       groupedPredictions[game.apiGameId] = [];
     }
     if (user.id !== currentUserId) {
-      groupedPredictions[game.apiGameId].push({ user: user.name, predictedTeam });
+      groupedPredictions[game.apiGameId].push({
+        user: user.name,
+        predictedTeam,
+      });
     }
   }
 
-  return groupedPredictions
-}
+  return groupedPredictions;
+};

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { formatInTimeZone } from "date-fns-tz";
+import { prisma } from "@/lib/db";
+import { sendUnbidReminder } from "@/lib/email";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const today = formatInTimeZone(
+      new Date(),
+      "America/New_York",
+      "yyyy-MM-dd",
+    );
+    const startOfDay = new Date(`${today}T00:00:00-04:00`);
+    const endOfDay = new Date(`${today}T23:59:59.999-04:00`);
+    const now = new Date();
+
+    // Get today's games that haven't started yet
+    const todaysUpcomingGames = await prisma.game.findMany({
+      where: {
+        startTime: {
+          gte: startOfDay,
+          lte: endOfDay,
+          gt: now,
+        },
+      },
+      orderBy: { startTime: "asc" },
+    });
+
+    if (todaysUpcomingGames.length === 0) {
+      return NextResponse.json({
+        ok: true,
+        message: "No upcoming games today",
+        emailsSent: 0,
+      });
+    }
+
+    // Get all users with email reminders enabled
+    const users = await prisma.user.findMany({
+      where: { emailReminders: true },
+      include: {
+        predictions: {
+          where: {
+            game: {
+              startTime: { gte: startOfDay, lte: endOfDay },
+            },
+          },
+          select: { gameId: true },
+        },
+      },
+    });
+
+    let emailsSent = 0;
+
+    for (const user of users) {
+      const predictedGameIds = new Set(user.predictions.map((p) => p.gameId));
+      const unbidGames = todaysUpcomingGames.filter(
+        (g) => !predictedGameIds.has(g.id),
+      );
+
+      if (unbidGames.length === 0) continue;
+
+      try {
+        const firstName = user.name?.split(" ")[0] || "there";
+        await sendUnbidReminder(
+          user.email,
+          firstName,
+          unbidGames.map((g) => ({
+            homeTeam: g.homeTeam,
+            awayTeam: g.awayTeam,
+            startTime: g.startTime,
+          })),
+        );
+        emailsSent++;
+        console.log(`Sent reminder to ${user.email}: ${unbidGames.length} unbid games`);
+      } catch (error) {
+        console.error(`Failed to send reminder to ${user.email}:`, error);
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      emailsSent,
+      totalUsers: users.length,
+      gamesAvailable: todaysUpcomingGames.length,
+    });
+  } catch (e) {
+    console.error("Send reminders cron failed:", e);
+    return NextResponse.json({ error: "Send reminders failed" }, { status: 500 });
+  }
+}

--- a/claude-implementation-plans/unbid-game-reminder.md
+++ b/claude-implementation-plans/unbid-game-reminder.md
@@ -1,0 +1,193 @@
+# Unbid Game Reminder System
+
+## Overview
+Add a reminder system to notify users when they have games they haven't placed predictions on. Split into two phases: in-app modal and email reminders.
+
+---
+
+## Phase 1: In-App Pop-up Modal
+
+### Goal
+When a user navigates to the predictions page, if they have today's games without predictions (and those games haven't started yet), show a modal reminding them.
+
+### Implementation Steps
+
+#### 1.1 Create Server Action: `fetchTodaysUnbidGames`
+- **File**: `actions/prediction.ts`
+- Add a new function that queries today's games where the current user has NO prediction and the game hasn't started yet
+- Uses Prisma's `none` relation filter:
+  ```typescript
+  export const fetchTodaysUnbidGames = async (userId: string, todayStr: string) => {
+    const startOfDay = new Date(`${todayStr}T00:00:00-04:00`);
+    const endOfDay = new Date(`${todayStr}T23:59:59.999-04:00`);
+    
+    return await prisma.game.findMany({
+      where: {
+        startTime: {
+          gte: startOfDay,
+          lte: endOfDay,
+          gt: new Date(), // hasn't started yet
+        },
+        predictions: {
+          none: { userId },
+        },
+      },
+      include: { round: true },
+      orderBy: { startTime: "asc" },
+    });
+  };
+  ```
+
+#### 1.2 Pass Unbid Games Data to Dashboard
+- **File**: `app/(protected)/predictions/page.tsx`
+- Call `fetchTodaysUnbidGames()` on page load
+- Pass the unbid games count/list to `PredictionDashboard` as a prop
+
+#### 1.3 Create `UnbidGamesModal` Component
+- **File**: `components/Predicitions/UnbidGamesModal.tsx` (keep in existing typo folder for consistency)
+- Uses shadcn `Dialog` component
+- Content:
+  - Title: "You have X game(s) to predict!"
+  - List of unbid games (home team vs away team, start time)
+  - "Go to predictions" button (closes modal, scrolls to today's games section)
+  - "Dismiss" / close button
+- **Show condition**: Only shows if unbid games > 0
+- **Session storage**: Use `sessionStorage` to only show once per browser session (key: `unbid-reminder-dismissed-{date}`), so it doesn't annoy users on every page navigation
+
+#### 1.4 Integrate Modal into PredictionDashboard
+- **File**: `components/Predicitions/PredictionDashboard.tsx`
+- Render `UnbidGamesModal` with unbid games data
+- Modal auto-opens on mount if there are unbid games and hasn't been dismissed this session
+
+### Phase 1 Files Changed
+| File | Change |
+|------|--------|
+| `actions/prediction.ts` | Add `fetchTodaysUnbidGames()` |
+| `app/(protected)/predictions/page.tsx` | Fetch unbid games, pass as prop |
+| `components/Predicitions/UnbidGamesModal.tsx` | **New** - Modal component |
+| `components/Predicitions/PredictionDashboard.tsx` | Render modal |
+
+---
+
+## Phase 2: Email Reminders (via Resend)
+
+### Goal
+Send daily email reminders to users who have unbid games for today. Users can opt in/out of email notifications.
+
+### Prerequisites
+- Resend account + API key
+- Add `RESEND_API_KEY` to environment variables (local `.env` + Vercel)
+- Optional: Verify custom domain in Resend for branded emails
+
+### Implementation Steps
+
+#### 2.1 Install Resend
+```bash
+npm install resend
+```
+
+#### 2.2 Database Changes
+- **File**: `prisma/schema.prisma`
+- Add notification preference to User model:
+  ```prisma
+  model User {
+    // ... existing fields
+    emailReminders  Boolean  @default(true)  // opt-in by default
+  }
+  ```
+- Run migration: `npx prisma migrate dev --name add-email-reminders`
+
+#### 2.3 Create Email Service
+- **File**: `lib/email.ts`
+- Initialize Resend client
+- Create `sendUnbidReminder()` function:
+  ```typescript
+  import { Resend } from 'resend';
+  
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  
+  export const sendUnbidReminder = async (
+    to: string, 
+    userName: string, 
+    unbidGames: { homeTeam: string; awayTeam: string; startTime: Date }[]
+  ) => {
+    await resend.emails.send({
+      from: 'NBA Predictor <onboarding@resend.dev>', // or custom domain
+      to,
+      subject: `You have ${unbidGames.length} game(s) to predict today!`,
+      html: buildReminderEmailHtml(userName, unbidGames),
+    });
+  };
+  ```
+
+#### 2.4 Create Email Template
+- **File**: `lib/email-templates/unbid-reminder.ts`
+- Build HTML email with:
+  - Greeting with user's name
+  - List of today's unbid games (teams + start time)
+  - CTA button linking to the predictions page
+  - Unsubscribe link/note
+- Keep it simple — inline CSS for email compatibility
+
+#### 2.5 Create Reminder Cron API Route
+- **File**: `app/api/cron/send-reminders/route.ts`
+- Protected by `CRON_SECRET` (same pattern as existing refresh-games cron)
+- Logic:
+  1. Get today's date (ET timezone)
+  2. Fetch all games for today that haven't started yet
+  3. For each user with `emailReminders: true`:
+     - Check which of today's games they haven't predicted
+     - If any unbid games → send reminder email
+  4. Return summary of emails sent
+- **Batch emails** to respect Resend rate limits (100/day free tier)
+
+#### 2.6 Register Cron in Vercel Config
+- **File**: `vercel.json` (or `vercel.ts`)
+- Add second cron job:
+  ```json
+  {
+    "crons": [
+      { "path": "/api/cron/refresh-games", "schedule": "0 10 * * *" },
+      { "path": "/api/cron/send-reminders", "schedule": "0 16 * * *" }
+    ]
+  }
+  ```
+- Schedule: **16:00 UTC (12:00 PM ET)** — gives users afternoon reminder before evening games
+- Note: Vercel Hobby plan supports multiple cron jobs (runs once/day each)
+
+#### 2.7 Add User Preferences UI
+- **File**: `components/Nav/NavBar.tsx` or create a settings dropdown
+- Add toggle for email reminders in user menu/avatar dropdown
+- Server action to update `emailReminders` preference:
+  ```typescript
+  export const updateEmailPreference = async (userId: string, enabled: boolean) => {
+    await prisma.user.update({
+      where: { id: userId },
+      data: { emailReminders: enabled },
+    });
+  };
+  ```
+
+### Phase 2 Files Changed
+| File | Change |
+|------|--------|
+| `prisma/schema.prisma` | Add `emailReminders` field to User |
+| `lib/email.ts` | **New** - Resend client & send function |
+| `lib/email-templates/unbid-reminder.ts` | **New** - Email HTML template |
+| `app/api/cron/send-reminders/route.ts` | **New** - Cron endpoint |
+| `vercel.json` | Add cron schedule |
+| `actions/user.ts` | Add `updateEmailPreference()` |
+| `components/Nav/NavBar.tsx` or new settings component | Email toggle UI |
+| `.env` | Add `RESEND_API_KEY` |
+
+---
+
+## Summary
+
+| | Phase 1 | Phase 2 |
+|---|---------|---------|
+| **Scope** | Small | Medium |
+| **External deps** | None | Resend |
+| **New files** | 1 | 3 |
+| **DB migration** | No | Yes |
+| **Cost** | Free | Free (under 100 emails/day) |

--- a/components/Nav/NavBar.tsx
+++ b/components/Nav/NavBar.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu, X, Trophy, BarChart3, Clock, BookOpen, Shield } from "lucide-react";
+import { Menu, X, Trophy, BarChart3, Clock, BookOpen, Shield, Bell, BellOff } from "lucide-react";
 import { Session } from "next-auth";
+import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -12,10 +13,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SignoutButton } from "@/components/Signout/SignoutButton";
 import { ThemeToggler } from "@/components/ThemeToggler/ThemeToggler";
+import { updateEmailReminders } from "@/actions/user";
 
 const NAV_ITEMS = [
   { href: "/predictions", label: "Predictions", icon: Trophy },
@@ -24,9 +27,34 @@ const NAV_ITEMS = [
   { href: "/rules", label: "Rules", icon: BookOpen },
 ];
 
-export const NavBar = ({ session, isAdmin }: { session: Session | null; isAdmin?: boolean }) => {
+export const NavBar = ({
+  session,
+  isAdmin,
+  userId,
+  emailReminders: initialEmailReminders,
+}: {
+  session: Session | null;
+  isAdmin?: boolean;
+  userId: string;
+  emailReminders: boolean;
+}) => {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [emailReminders, setEmailReminders] = useState(initialEmailReminders);
   const pathname = usePathname();
+
+  const handleToggleEmailReminders = async () => {
+    const newValue = !emailReminders;
+    setEmailReminders(newValue);
+    try {
+      await updateEmailReminders(userId, newValue);
+      toast.success(
+        newValue ? "Email reminders enabled" : "Email reminders disabled",
+      );
+    } catch {
+      setEmailReminders(!newValue);
+      toast.error("Failed to update email preference");
+    }
+  };
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-lg">
@@ -107,6 +135,19 @@ export const NavBar = ({ session, isAdmin }: { session: Session | null; isAdmin?
                   <span className="font-medium">{session.user.name}</span>
                   <span className="text-xs text-muted-foreground">{session.user.email}</span>
                 </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={handleToggleEmailReminders}
+                  className="cursor-pointer"
+                >
+                  {emailReminders ? (
+                    <Bell className="mr-2 h-4 w-4" />
+                  ) : (
+                    <BellOff className="mr-2 h-4 w-4" />
+                  )}
+                  Email Reminders: {emailReminders ? "On" : "Off"}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
                 <DropdownMenuItem>
                   <SignoutButton />
                 </DropdownMenuItem>

--- a/components/Predicitions/PredictionDashboard.tsx
+++ b/components/Predicitions/PredictionDashboard.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/popover";
 import AllGamesSection from "@/components/Games/AllGamesSection";
 import TodaysGamesSection from "@/components/Games/TodaysGameSection";
+import UnbidGamesModal from "@/components/Predicitions/UnbidGamesModal";
 import { Game } from "@/types/IGames";
 import { PredictionMap } from "@/types/IPredictions";
 
@@ -28,6 +29,7 @@ type PredictionsDashboardProps = {
   currentUserGuesses: Record<number, string>;
   allOtherGameGuesses: PredictionMap;
   rounds: RoundOption[];
+  unbidGames: Game[];
 };
 
 export default function PredictionsDashboard({
@@ -36,6 +38,7 @@ export default function PredictionsDashboard({
   currentUserGuesses,
   allOtherGameGuesses,
   rounds,
+  unbidGames,
 }: PredictionsDashboardProps) {
   const [guesses, setGuesses] = useState<Record<number, string>>(currentUserGuesses);
 
@@ -54,6 +57,8 @@ export default function PredictionsDashboard({
 
   return (
     <main className="mx-auto max-w-5xl space-y-8 px-4 py-8">
+      <UnbidGamesModal unbidGames={unbidGames} />
+
       {/* Header */}
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight">Predictions</h1>

--- a/components/Predicitions/UnbidGamesModal.tsx
+++ b/components/Predicitions/UnbidGamesModal.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { formatInTimeZone } from "date-fns-tz";
+import { AlertTriangle, Clock } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Game } from "@/types/IGames";
+
+interface UnbidGamesModalProps {
+  unbidGames: Game[];
+}
+
+export default function UnbidGamesModal({ unbidGames }: UnbidGamesModalProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (unbidGames.length === 0) return;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const key = `unbid-reminder-dismissed-${today}`;
+    if (sessionStorage.getItem(key)) return;
+
+    setOpen(true);
+  }, [unbidGames]);
+
+  const handleDismiss = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    sessionStorage.setItem(`unbid-reminder-dismissed-${today}`, "1");
+    setOpen(false);
+  };
+
+  if (unbidGames.length === 0) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleDismiss()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            You have {unbidGames.length} game
+            {unbidGames.length > 1 ? "s" : ""} to predict!
+          </DialogTitle>
+          <DialogDescription>
+            Don&apos;t miss out on earning points — make your picks before the
+            games start.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          {unbidGames.map((game) => (
+            <div
+              key={game.id}
+              className="flex items-center justify-between rounded-lg border p-3"
+            >
+              <span className="text-sm font-medium">
+                {game.visitor_team.name} @ {game.home_team.name}
+              </span>
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <Clock className="h-3 w-3" />
+                {formatInTimeZone(
+                  new Date(game.datetime),
+                  "America/New_York",
+                  "h:mm a",
+                )}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleDismiss} className="w-full cursor-pointer">
+            Got it, let me pick!
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,101 @@
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+const FROM_ADDRESS = "NBA Predictor <onboarding@resend.dev>";
+
+interface UnbidGame {
+  homeTeam: string;
+  awayTeam: string;
+  startTime: Date;
+}
+
+export const sendUnbidReminder = async (
+  to: string,
+  userName: string,
+  unbidGames: UnbidGame[],
+) => {
+  const gameRows = unbidGames
+    .map((g) => {
+      const time = g.startTime.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        timeZone: "America/New_York",
+      });
+      return `
+        <tr>
+          <td style="padding: 12px 16px; border-bottom: 1px solid #e5e7eb;">
+            <strong>${g.awayTeam}</strong> @ <strong>${g.homeTeam}</strong>
+          </td>
+          <td style="padding: 12px 16px; border-bottom: 1px solid #e5e7eb; text-align: right; color: #6b7280;">
+            ${time} ET
+          </td>
+        </tr>`;
+    })
+    .join("");
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body style="margin: 0; padding: 0; background-color: #f3f4f6; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+  <div style="max-width: 560px; margin: 40px auto; background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+
+    <!-- Header -->
+    <div style="background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%); padding: 32px 24px; text-align: center;">
+      <h1 style="margin: 0; color: #f97316; font-size: 22px; font-weight: 700;">NBA Predictor</h1>
+      <p style="margin: 8px 0 0; color: #94a3b8; font-size: 14px;">Game Day Reminder</p>
+    </div>
+
+    <!-- Body -->
+    <div style="padding: 24px;">
+      <p style="margin: 0 0 16px; color: #1f2937; font-size: 16px;">
+        Hey ${userName || "there"},
+      </p>
+      <p style="margin: 0 0 20px; color: #4b5563; font-size: 14px; line-height: 1.6;">
+        You have <strong>${unbidGames.length} game${unbidGames.length > 1 ? "s" : ""}</strong> today that you haven't predicted yet. Make sure to lock in your picks before tip-off — once a game starts, predictions are locked!
+      </p>
+
+      <!-- Games Table -->
+      <table style="width: 100%; border-collapse: collapse; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden;">
+        <thead>
+          <tr style="background: #f9fafb;">
+            <th style="padding: 10px 16px; text-align: left; font-size: 12px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;">Matchup</th>
+            <th style="padding: 10px 16px; text-align: right; font-size: 12px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${gameRows}
+        </tbody>
+      </table>
+
+      <!-- CTA Button -->
+      <div style="text-align: center; margin-top: 24px;">
+        <a href="${process.env.NEXT_PUBLIC_APP_URL || "https://nba-prediction-for-fun.vercel.app"}/predictions"
+           style="display: inline-block; background: #f97316; color: #ffffff; padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 14px;">
+          Make Your Picks
+        </a>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div style="padding: 16px 24px; background: #f9fafb; text-align: center;">
+      <p style="margin: 0; color: #9ca3af; font-size: 12px;">
+        You're receiving this because you have email reminders enabled.
+        Log in to your account to change notification preferences.
+      </p>
+    </div>
+  </div>
+</body>
+</html>`;
+
+  return await resend.emails.send({
+    from: FROM_ADDRESS,
+    to,
+    subject: `You have ${unbidGames.length} game${unbidGames.length > 1 ? "s" : ""} to predict today!`,
+    html,
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "react-hook-form": "^7.55.0",
         "react-resizable-panels": "^2.1.7",
         "recharts": "^2.15.2",
+        "resend": "^6.10.0",
         "sonner": "^2.0.3",
         "tailwind-merge": "^3.1.0",
         "tw-animate-css": "^1.2.5",
@@ -2959,6 +2960,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -5936,6 +5943,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -8099,6 +8112,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -8732,6 +8751,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resend": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.10.0.tgz",
+      "integrity": "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.88.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -9158,6 +9198,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -9476,6 +9526,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
+      "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -10060,6 +10120,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vaul": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-hook-form": "^7.55.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
+    "resend": "^6.10.0",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.1.0",
     "tw-animate-css": "^1.2.5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,13 +14,14 @@ enum Role {
 }
 
 model User {
-  id          String       @id @default(cuid())
-  email       String       @unique
-  name        String?
-  image       String?
-  predictions Prediction[]
-  createdAt   DateTime     @default(now())
-  role        Role         @default(USER)
+  id             String       @id @default(cuid())
+  email          String       @unique
+  name           String?
+  image          String?
+  predictions    Prediction[]
+  createdAt      DateTime     @default(now())
+  role           Role         @default(USER)
+  emailReminders Boolean      @default(true)
 }
 
 model Round {

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/refresh-games",
       "schedule": "0 10 * * *"
+    },
+    {
+      "path": "/api/cron/send-reminders",
+      "schedule": "0 16 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add in-app pop-up modal on predictions page reminding users of today's unbid games (with matchups and times, dismissed per session)
- Add daily email reminders via Resend at 12:00 PM ET for users with unpredicted games
- Add email reminder toggle (on/off) in user dropdown menu
- Add `emailReminders` field to User model, new cron endpoint `/api/cron/send-reminders`

## Test plan
- [ ] Visit predictions page with unbid games today — modal should appear
- [ ] Dismiss modal, navigate away and back — modal should not reappear in same session
- [ ] Toggle email reminders off/on in user dropdown menu
- [ ] Verify cron endpoint sends emails only to users with `emailReminders: true` and unbid games
- [ ] Verify email displays correct branding, first name, game matchups, and times in ET