### PR TITLE
feat: hide predicted team on prediction cards to prevent bias

### DIFF
--- a/components/Predicitions/GameCard.tsx
+++ b/components/Predicitions/GameCard.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { formatInTimeZone } from "date-fns-tz";
 import { getTeamLogoUrl } from "@/constants/teams";
-import { Calendar, Clock, Trophy } from "lucide-react";
+import { Calendar, Clock, Lock, Trophy } from "lucide-react";
 
 import { Game } from "@/types/IGames";
 import { PredictionMap } from "@/types/IPredictions";
@@ -147,7 +147,10 @@ export const GameCard = ({ game, predictedTeam, onGuess, allOtherGameGuesses }: 
               >
                 <AvatarBadge avatar={guess.avatar} favoriteTeam={guess.favoriteTeam} size={14} />
                 <span className="font-medium">{guess.user}</span>
-                <span className="text-muted-foreground">{guess.predictedTeam}</span>
+                <span className="inline-flex items-center gap-1 text-muted-foreground">
+                  <Lock className="h-3 w-3" />
+                  Picked
+                </span>
               </span>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Replace team name with `Lock` icon + `Picked` placeholder in the All Picks section of the prediction card
- Past Games page still shows full prediction details (team name + correctness)
- Goal: stop new users from seeing what team others picked, which was causing herd-following bias

## Test plan
- [ ] Log in, go to `/predictions`, verify each GameCard's All Picks area shows `avatar + username + 🔒 Picked` (no team name)
- [ ] Go to `/pastGames`, verify each past game still shows full prediction details with correctness indicator
- [ ] Verify preview deployment renders correctly on mobile and desktop