### PR TITLE
feat: add win rate and W/L stats to leaderboard

### DIFF
--- a/actions/leaderboard.ts
+++ b/actions/leaderboard.ts
@@ -6,9 +6,6 @@ export async function getLeaderboard() {
   const users = await prisma.user.findMany({
     include: {
       predictions: {
-        where: {
-          isCorrect: true,
-        },
         include: {
           game: {
             include: {
@@ -21,9 +18,23 @@ export async function getLeaderboard() {
   });
 
   const leaderboard = users.map((user) => {
-    const totalPoints = user.predictions.reduce((sum, prediction) => {
-      return sum + (prediction?.game?.round?.point ?? 0);
-    }, 0);
+    let totalPoints = 0;
+    let wins = 0;
+    let losses = 0;
+
+    for (const prediction of user.predictions) {
+      if (!prediction.game?.round) continue;
+
+      if (prediction.isCorrect === true) {
+        wins += 1;
+        totalPoints += prediction.game.round.point;
+      } else if (prediction.isCorrect === false) {
+        losses += 1;
+      }
+    }
+
+    const decided = wins + losses;
+    const winRate = decided > 0 ? wins / decided : null;
 
     return {
       id: user.id,
@@ -33,6 +44,9 @@ export async function getLeaderboard() {
       favoriteTeam: user.favoriteTeam,
       avatar: user.avatar,
       totalPoints,
+      wins,
+      losses,
+      winRate,
     };
   });
 

--- a/app/(protected)/leaderboard/page.tsx
+++ b/app/(protected)/leaderboard/page.tsx
@@ -1,6 +1,6 @@
 import { getLeaderboard } from "@/actions/leaderboard";
 import { getCurrentUser } from "@/actions/user";
-import { BarChart3, Medal, Trophy } from "lucide-react";
+import { BarChart3, Check, Medal, Target, Trophy, X } from "lucide-react";
 import Image from "next/image";
 import AvatarBadge from "@/components/AvatarBadge";
 import TeamBadge from "@/components/TeamBadge";
@@ -80,14 +80,34 @@ export default async function LeaderboardPage() {
                   {user.favoriteTeam && (
                     <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
                       <TeamBadge teamName={user.favoriteTeam} size={14} />
-                      <span>{user.favoriteTeam} fan</span>
+                      <span className="truncate">{user.favoriteTeam} fan</span>
                     </p>
                   )}
+                  <div className="mt-1 flex items-center gap-2 text-xs tabular-nums">
+                    <span className="inline-flex items-center gap-0.5 font-medium text-emerald-600 dark:text-emerald-400">
+                      <Check className="h-3 w-3" strokeWidth={3} />
+                      {user.wins}
+                    </span>
+                    <span className="text-muted-foreground/40">·</span>
+                    <span className="inline-flex items-center gap-0.5 font-medium text-rose-600 dark:text-rose-400">
+                      <X className="h-3 w-3" strokeWidth={3} />
+                      {user.losses}
+                    </span>
+                    {user.winRate !== null && (
+                      <>
+                        <span className="text-muted-foreground/40">·</span>
+                        <span className="inline-flex items-center gap-0.5 font-medium text-muted-foreground">
+                          <Target className="h-3 w-3" />
+                          {Math.round(user.winRate * 100)}%
+                        </span>
+                      </>
+                    )}
+                  </div>
                 </div>
               </div>
 
               {/* Points */}
-              <div className="flex items-center gap-1.5">
+              <div className="flex shrink-0 items-center gap-1.5">
                 {isTop3 && <Trophy className="h-4 w-4 text-primary" />}
                 <span className="text-xl font-bold tabular-nums">
                   {user.totalPoints}

--- a/scripts/debug-leaderboard.ts
+++ b/scripts/debug-leaderboard.ts
@@ -1,0 +1,89 @@
+import { prisma } from "../lib/db";
+
+async function main() {
+  const email = process.argv[2];
+  if (!email) {
+    console.log("Usage: npx tsx scripts/debug-leaderboard.ts <email>");
+    process.exit(1);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    include: {
+      predictions: {
+        include: {
+          game: { include: { round: true } },
+        },
+      },
+    },
+  });
+
+  if (!user) {
+    console.log(`User ${email} not found`);
+    process.exit(1);
+  }
+
+  console.log(`\n=== ${user.name} (${user.email}) ===`);
+  console.log(`Total predictions in DB: ${user.predictions.length}\n`);
+
+  const byRound: Record<
+    string,
+    { wins: number; losses: number; pending: number; games: string[] }
+  > = {};
+  const noRound: { wins: number; losses: number; pending: number } = {
+    wins: 0,
+    losses: 0,
+    pending: 0,
+  };
+
+  for (const p of user.predictions) {
+    const roundName = p.game?.round?.name ?? null;
+    const label = `${p.game.awayTeam} @ ${p.game.homeTeam} (${p.game.startTime.toISOString().slice(0, 10)}) [${p.game.status}] isPlayoff=${p.game.isPlayoff} isCorrect=${p.isCorrect}`;
+
+    if (!roundName) {
+      if (p.isCorrect === true) noRound.wins += 1;
+      else if (p.isCorrect === false) noRound.losses += 1;
+      else noRound.pending += 1;
+      continue;
+    }
+
+    byRound[roundName] ??= { wins: 0, losses: 0, pending: 0, games: [] };
+    if (p.isCorrect === true) byRound[roundName].wins += 1;
+    else if (p.isCorrect === false) byRound[roundName].losses += 1;
+    else byRound[roundName].pending += 1;
+    byRound[roundName].games.push(label);
+  }
+
+  console.log("--- By Round (counted in leaderboard) ---");
+  for (const [round, stats] of Object.entries(byRound)) {
+    console.log(
+      `${round}: ${stats.wins}W / ${stats.losses}L / ${stats.pending} pending  (total ${stats.wins + stats.losses + stats.pending})`,
+    );
+  }
+
+  console.log("\n--- No Round (NOT counted) ---");
+  console.log(
+    `${noRound.wins}W / ${noRound.losses}L / ${noRound.pending} pending`,
+  );
+
+  const totalCounted = Object.values(byRound).reduce(
+    (acc, r) => acc + r.wins + r.losses,
+    0,
+  );
+  const totalWins = Object.values(byRound).reduce((acc, r) => acc + r.wins, 0);
+  const totalLosses = Object.values(byRound).reduce(
+    (acc, r) => acc + r.losses,
+    0,
+  );
+  console.log(
+    `\nLeaderboard shows: ${totalWins}W / ${totalLosses}L (decided: ${totalCounted})`,
+  );
+
+  console.log("\n--- Game Detail (by round) ---");
+  for (const [round, stats] of Object.entries(byRound)) {
+    console.log(`\n### ${round} (${stats.games.length} games)`);
+    stats.games.forEach((g) => console.log(`  ${g}`));
+  }
+}
+
+main().finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

- Show each user's wins, losses, and win rate beside their name on the leaderboard
- Align W/L count with points scoring — only predictions on games with an assigned round are counted
- Add a small diagnostic script for future leaderboard debugging

## UI

Below each user's name / favorite team line, a compact stats row:

- `✓ <wins>` in emerald
- `✗ <losses>` in rose
- `🎯 <win%>` in muted (hidden when user has no decided predictions)

Right side still shows total points as the primary metric.

## Notes

- Win rate denominator only counts decided predictions (excludes pending games)
- Any round assigned via admin panel counts toward W/L and points (Regular Season 0.5pt, Play In 1pt, First Round 1.5pt, etc.)
- `scripts/debug-leaderboard.ts` can be run with `npx tsx scripts/debug-leaderboard.ts <email>` for per-round breakdown

## Test plan

- [ ] Leaderboard loads and shows W/L/% below each user's name
- [ ] Current user row still highlighted with primary ring
- [ ] Top 3 medal styling preserved
- [ ] Users with 0 decided predictions show `✓ 0 · ✗ 0` without a percentage
- [ ] Dark mode colors look correct
- [ ] Mobile layout does not overflow